### PR TITLE
Add an option to silently reject

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -352,8 +352,8 @@ type Ruleset struct {
 
 	ListAllowDomain string `sconf:"optional" sconf-doc:"Influence the spam filtering, this does not change whether this ruleset applies to a message. If this domain matches an SPF- and/or DKIM-verified (sub)domain, the message is accepted without further spam checks, such as a junk filter or DMARC reject evaluation. DMARC rejects should not apply for mailing lists that are not configured to rewrite the From-header of messages that don't have a passing DKIM signature of the From-domain. Otherwise, by rejecting messages, you may be automatically unsubscribed from the mailing list. The assumption is that mailing lists do their own spam filtering/moderation."`
 
-	Mailbox    string `sconf-doc:"Mailbox to deliver to if this ruleset matches."`
-	SoftReject bool   `sconf-doc:"Emails matching this rule will be accepted but not put in the rejects folder. This can be used for incoming mail forwards from a user's account at another provider."`
+	Mailbox    string `sconf:"optional" sconf-doc:"Mailbox to deliver to if this ruleset matches."`
+	SoftReject bool   `sconf:"optional" sconf-doc:"Emails matching this rule will be accepted but not put in the rejects folder. This can be used for incoming mail forwards from a user's account at another provider."`
 
 	SMTPMailFromRegexpCompiled *regexp.Regexp      `sconf:"-" json:"-"`
 	VerifiedDNSDomain          dns.Domain          `sconf:"-"`

--- a/config/config.go
+++ b/config/config.go
@@ -352,7 +352,8 @@ type Ruleset struct {
 
 	ListAllowDomain string `sconf:"optional" sconf-doc:"Influence the spam filtering, this does not change whether this ruleset applies to a message. If this domain matches an SPF- and/or DKIM-verified (sub)domain, the message is accepted without further spam checks, such as a junk filter or DMARC reject evaluation. DMARC rejects should not apply for mailing lists that are not configured to rewrite the From-header of messages that don't have a passing DKIM signature of the From-domain. Otherwise, by rejecting messages, you may be automatically unsubscribed from the mailing list. The assumption is that mailing lists do their own spam filtering/moderation."`
 
-	Mailbox string `sconf-doc:"Mailbox to deliver to if this ruleset matches."`
+	Mailbox    string `sconf-doc:"Mailbox to deliver to if this ruleset matches."`
+	SoftReject bool   `sconf-doc:"Emails matching this rule will be accepted but not put in the rejects folder. This can be used for incoming mail forwards from a user's account at another provider."`
 
 	SMTPMailFromRegexpCompiled *regexp.Regexp      `sconf:"-" json:"-"`
 	VerifiedDNSDomain          dns.Domain          `sconf:"-"`

--- a/config/config.go
+++ b/config/config.go
@@ -353,7 +353,7 @@ type Ruleset struct {
 	ListAllowDomain string `sconf:"optional" sconf-doc:"Influence the spam filtering, this does not change whether this ruleset applies to a message. If this domain matches an SPF- and/or DKIM-verified (sub)domain, the message is accepted without further spam checks, such as a junk filter or DMARC reject evaluation. DMARC rejects should not apply for mailing lists that are not configured to rewrite the From-header of messages that don't have a passing DKIM signature of the From-domain. Otherwise, by rejecting messages, you may be automatically unsubscribed from the mailing list. The assumption is that mailing lists do their own spam filtering/moderation."`
 
 	Mailbox    string `sconf:"optional" sconf-doc:"Mailbox to deliver to if this ruleset matches."`
-	SoftReject bool   `sconf:"optional" sconf-doc:"Emails matching this rule will be accepted but not put in the rejects folder. This can be used for incoming mail forwards from a user's account at another provider."`
+	SoftReject bool   `sconf:"optional" sconf-doc:"Emails matching this rule will be accepted but can still be put in the rejects folder. This can be used for incoming mail forwards from a user's account at another provider: spam will still be rejected but the forwarding host will treat it as accepted."`
 
 	SMTPMailFromRegexpCompiled *regexp.Regexp      `sconf:"-" json:"-"`
 	VerifiedDNSDomain          dns.Domain          `sconf:"-"`

--- a/smtpserver/analyze.go
+++ b/smtpserver/analyze.go
@@ -72,7 +72,10 @@ func analyze(ctx context.Context, log *mlog.Log, resolver dns.Resolver, d delive
 	// check it for a pass.
 	// todo: should use this evaluation for final delivery as well
 	rs := store.MessageRuleset(log, d.rcptAcc.destination, d.m, d.m.MsgPrefix, d.dataFile)
-	softReject := rs.SoftReject
+	var softReject bool
+	if rs != nil {
+		softReject = rs.SoftReject
+	}
 
 	reject := func(code int, secode string, errmsg string, err error, reason string) analysis {
 		return analysis{false, softReject, code, secode, err == nil, errmsg, err, nil, nil, reason}

--- a/smtpserver/server.go
+++ b/smtpserver/server.go
@@ -2445,7 +2445,10 @@ func (c *conn) deliver(ctx context.Context, recvHdrFor func(string) string, msgW
 			log.Info("incoming message rejected", mlog.Field("reason", a.reason), mlog.Field("msgfrom", msgFrom))
 			metricDelivery.WithLabelValues("reject", a.reason).Inc()
 			c.setSlow(true)
-			addError(rcptAcc, a.code, a.secode, a.userError, a.errmsg)
+
+			if !a.softReject {
+				addError(rcptAcc, a.code, a.secode, a.userError, a.errmsg)
+			}
 			continue
 		}
 

--- a/smtpserver/server.go
+++ b/smtpserver/server.go
@@ -2446,7 +2446,9 @@ func (c *conn) deliver(ctx context.Context, recvHdrFor func(string) string, msgW
 			metricDelivery.WithLabelValues("reject", a.reason).Inc()
 			c.setSlow(true)
 
-			if !a.softReject {
+			if a.softReject {
+				log.Info("silently rejecting message due to soft reject rule")
+			} else {
 				addError(rcptAcc, a.code, a.secode, a.userError, a.errmsg)
 			}
 			continue

--- a/store/account.go
+++ b/store/account.go
@@ -1006,7 +1006,7 @@ func (a *Account) MessageReader(m Message) *MsgReader {
 func (a *Account) Deliver(log *mlog.Log, dest config.Destination, m *Message, msgFile *os.File, consumeFile bool) error {
 	var mailbox string
 	rs := MessageRuleset(log, dest, m, m.MsgPrefix, msgFile)
-	if rs != nil {
+	if rs != nil && rs.Mailbox != "" {
 		mailbox = rs.Mailbox
 	} else if dest.Mailbox == "" {
 		mailbox = "Inbox"


### PR DESCRIPTION
Spam forwarded from my Gmail account is redelivered because mox rejects it. I want mox to process it as if it's spam but not tell Gmail, so it doesn't try to redeliver it.