### PR TITLE
Treat messages as text

### DIFF
--- a/webmail/webmail.js
+++ b/webmail/webmail.js
@@ -2915,7 +2915,7 @@ const newMsgView = (miv, msglistView, listMailboxes, possibleLabels, messageLoad
 		'image/apng',
 		'image/svg+xml',
 	];
-	const isText = (a) => a.Part.MediaType.toLowerCase() === 'text';
+	const isText = (a) => ['text', 'message'].includes(a.Part.MediaType.toLowerCase());
 	const isImage = (a) => imageTypes.includes((a.Part.MediaType + '/' + a.Part.MediaSubType).toLowerCase());
 	const isPDF = (a) => (a.Part.MediaType + '/' + a.Part.MediaSubType).toLowerCase() === 'application/pdf';
 	const isViewable = (a) => isText(a) || isImage(a) || isPDF(a);

--- a/webmail/webmail.ts
+++ b/webmail/webmail.ts
@@ -2463,7 +2463,7 @@ const newMsgView = (miv: MsgitemView, msglistView: MsglistView, listMailboxes: l
 		'image/apng',
 		'image/svg+xml',
 	]
-	const isText = (a: api.Attachment) => a.Part.MediaType.toLowerCase() === 'text'
+	const isText = (a: api.Attachment) => ['text', 'message'].includes(a.Part.MediaType.toLowerCase())
 	const isImage = (a: api.Attachment) => imageTypes.includes((a.Part.MediaType + '/' + a.Part.MediaSubType).toLowerCase())
 	const isPDF = (a: api.Attachment) => (a.Part.MediaType+'/'+a.Part.MediaSubType).toLowerCase() === 'application/pdf'
 	const isViewable = (a: api.Attachment) => isText(a) || isImage(a) || isPDF(a)


### PR DESCRIPTION
SMTP messages, which sometimes appear as attachments, are currently treated as "possibly binary" by mox webmail. Since SMTP messages are ASCII, we should be able to treat them as text.