### PR TITLE
Improve portability of build scripts

### DIFF
--- a/gendoc.sh
+++ b/gendoc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 (
 cat <<EOF

--- a/gents.sh
+++ b/gents.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # generate new typescript client, only install it when it is different, so we

--- a/tsc.sh
+++ b/tsc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # - todo: get tsc to not emit semicolons except for the handful cases where it is needed.


### PR DESCRIPTION
Not all systems have bash (and maybe sh) in the hardcoded path, so use /usr/bin/env to reach the target.

That allows to build mox on FreeBSD for example.