### PR TITLE
Set syslog facility to mail

### DIFF
--- a/mox.service
+++ b/mox.service
@@ -13,6 +13,7 @@ ExecStart=/home/mox/mox serve
 RestartSec=5s
 Restart=always
 ExecStop=/home/mox/mox stop
+SyslogFacility=mail
 
 # Isolate process, reducing attack surface.
 PrivateDevices=yes


### PR DESCRIPTION
Setting syslog facility to mail will redirect log output to `/var/log/mail.log` instead of the `/var/log/syslog` file