### PR TITLE
Split paste into address fields by commas

### DIFF
--- a/webmail/webmail.js
+++ b/webmail/webmail.js
@@ -2862,6 +2862,23 @@ const compose = (opts, listMailboxes) => {
 		}, function change() {
 			autosizeElem.dataset.value = inputElem.value;
 			fetchRecipientSecurity();
+		}, function paste(e) {
+			const data = e.clipboardData?.getData('text/plain');
+			if (typeof data !== 'string' || data === '') {
+				return;
+			}
+			const split = data.split(',');
+			if (split.length <= 1) {
+				return;
+			}
+			autosizeElem.dataset.value = inputElem.value = split[0];
+			let last;
+			for (const rest of split.splice(1)) {
+				last = newAddrView(rest.trim(), isRecipient, views, btn, cell, row, single);
+			}
+			last.input.focus();
+			e.preventDefault();
+			e.stopPropagation();
 		}), securityBar = dom.span(css('securitybar', {
 			margin: '0 1px',
 			borderBottom: '1.5px solid',

--- a/webmail/webmail.ts
+++ b/webmail/webmail.ts
@@ -1785,6 +1785,24 @@ const compose = (opts: ComposeOptions, listMailboxes: listMailboxes) => {
 						autosizeElem.dataset.value = inputElem.value
 						fetchRecipientSecurity()
 					},
+					function paste(e: ClipboardEvent) {
+						const data = e.clipboardData?.getData('text/plain')
+						if (typeof data !== 'string' || data === '') {
+							return
+						}
+						const split = data.split(',')
+						if (split.length <= 1) {
+							return
+						}
+						autosizeElem.dataset.value = inputElem.value = split[0]
+						let last
+						for (const rest of split.splice(1)) {
+							last = newAddrView(rest.trim(), isRecipient, views, btn, cell, row, single)
+						}
+						last!!.input.focus()
+						e.preventDefault()
+						e.stopPropagation()
+					},
 				),
 				securityBar=dom.span(
 					css('securitybar', {


### PR DESCRIPTION
If the user has a list of addresses in the clipboard and pastes it in, split the input to have one field for each comma-separated entry. This is more user-friendly.

I don't know if there are cases where a comma in the field is necessary, but if so we could possibly add a workaround by holding a key, e.g. Ctrl+Shift+V for "raw paste" without the splitting behaviour.