### PR TITLE
Allow `mox serve` to run unprivileged

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,7 @@ any parameters. Followed by the help and usage information for each command.
 # Usage
 
 	mox [-config config/mox.conf] [-pedantic] ...
-	mox serve
+	mox serve [-unprivileged]
 	mox quickstart [-skipdial] [-existing-webserver] [-hostname host] user@domain [user | uid]
 	mox stop
 	mox setaccountpassword account
@@ -144,7 +144,9 @@ requested, other TLS certificates are requested on demand.
 
 Only implemented on unix systems, not Windows.
 
-	usage: mox serve
+	usage: mox serve [-unprivileged]
+	  -unprivileged
+	    	run mox as unprivileged user
 
 # mox quickstart
 

--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,7 @@ any parameters. Followed by the help and usage information for each command.
 # Usage
 
 	mox [-config config/mox.conf] [-pedantic] ...
-	mox serve
+	mox serve [-unprivileged]
 	mox quickstart [-skipdial] [-existing-webserver] [-hostname host] $user@domain [$user | $uid]
 	mox stop
 	mox setaccountpassword $account
@@ -146,7 +146,9 @@ requested, other TLS certificates are requested on demand.
 
 Only implemented on unix systems, not Windows.
 
-	usage: mox serve
+	usage: mox serve [-unprivileged]
+	  -unprivileged
+	    	run mox as unprivileged user
 
 # mox quickstart
 


### PR DESCRIPTION
Well, I converted this to a pull request since I guess we can think a little bit more on going forward with this.

As discussed and mentioned by @mjl- in #194, I don't see a clear path going forward with `CAP_NET_BIND_SERVICE`, so I'm dropping this one (even though at least FreeBSD provides a way to do that using `sysctl` but I find it insecure since it allows privileged ports *to everyone*.)
