### PR TITLE
fix typos in referrer header

### DIFF
--- a/http/web.go
+++ b/http/web.go
@@ -352,7 +352,7 @@ func (w *loggingWriter) Done() {
 		slog.Any("remoteaddr", w.R.RemoteAddr),
 		slog.String("tlsinfo", tlsinfo),
 		slog.String("useragent", w.R.Header.Get("User-Agent")),
-		slog.String("referrr", w.R.Header.Get("Referrer")),
+		slog.String("referer", w.R.Header.Get("Referer")),
 	}
 	if w.WebsocketRequest {
 		attrs = append(attrs,


### PR DESCRIPTION
It should be referer in both cases, which whilst misspelled is the actual header name