### PR TITLE
Log the correct remote address when listeners are forwarded, and allow Forwarded: true for MTS-STS and autoconfig endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -199,14 +199,16 @@ type Listener struct {
 		Port    int `sconf:"optional" sconf-doc:"Default 8011."`
 	} `sconf:"optional" sconf-doc:"Serve /debug/pprof/ for profiling a running mox instance. Do not enable this on a public IP!"`
 	AutoconfigHTTPS struct {
-		Enabled bool
-		Port    int  `sconf:"optional" sconf-doc:"TLS port, 443 by default. You should only override this if you cannot listen on port 443 directly. Autoconfig requests will be made to port 443, so you'll have to add an external mechanism to get the connection here, e.g. by configuring port forwarding."`
-		NonTLS  bool `sconf:"optional" sconf-doc:"If set, plain HTTP instead of HTTPS is spoken on the configured port. Can be useful when the autoconfig domain is reverse proxied."`
+		Enabled   bool
+		Port      int  `sconf:"optional" sconf-doc:"TLS port, 443 by default. You should only override this if you cannot listen on port 443 directly. Autoconfig requests will be made to port 443, so you'll have to add an external mechanism to get the connection here, e.g. by configuring port forwarding."`
+		NonTLS    bool `sconf:"optional" sconf-doc:"If set, plain HTTP instead of HTTPS is spoken on the configured port. Can be useful when the autoconfig domain is reverse proxied."`
+		Forwarded bool `sconf:"optional" sconf-doc:"If set, X-Forwarded-* headers are used for the remote IP address for rate limiting and for the \"secure\" status of cookies."`
 	} `sconf:"optional" sconf-doc:"Serve autoconfiguration/autodiscovery to simplify configuring email applications, will use port 443. Requires a TLS config."`
 	MTASTSHTTPS struct {
-		Enabled bool
-		Port    int  `sconf:"optional" sconf-doc:"TLS port, 443 by default. You should only override this if you cannot listen on port 443 directly. MTA-STS requests will be made to port 443, so you'll have to add an external mechanism to get the connection here, e.g. by configuring port forwarding."`
-		NonTLS  bool `sconf:"optional" sconf-doc:"If set, plain HTTP instead of HTTPS is spoken on the configured port. Can be useful when the mta-sts domain is reverse proxied."`
+		Enabled   bool
+		Port      int  `sconf:"optional" sconf-doc:"TLS port, 443 by default. You should only override this if you cannot listen on port 443 directly. MTA-STS requests will be made to port 443, so you'll have to add an external mechanism to get the connection here, e.g. by configuring port forwarding."`
+		NonTLS    bool `sconf:"optional" sconf-doc:"If set, plain HTTP instead of HTTPS is spoken on the configured port. Can be useful when the mta-sts domain is reverse proxied."`
+		Forwarded bool `sconf:"optional" sconf-doc:"If set, X-Forwarded-* headers are used for the remote IP address for rate limiting and for the \"secure\" status of cookies."`
 	} `sconf:"optional" sconf-doc:"Serve MTA-STS policies describing SMTP TLS requirements. Requires a TLS config."`
 	WebserverHTTP struct {
 		Enabled           bool

--- a/config/doc.go
+++ b/config/doc.go
@@ -497,6 +497,10 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# useful when the autoconfig domain is reverse proxied. (optional)
 				NonTLS: false
 
+				# If set, X-Forwarded-* headers are used for the remote IP address for rate
+				# limiting and for the "secure" status of cookies. (optional)
+				Forwarded: false
+
 			# Serve MTA-STS policies describing SMTP TLS requirements. Requires a TLS config.
 			# (optional)
 			MTASTSHTTPS:
@@ -511,6 +515,10 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# If set, plain HTTP instead of HTTPS is spoken on the configured port. Can be
 				# useful when the mta-sts domain is reverse proxied. (optional)
 				NonTLS: false
+
+				# If set, X-Forwarded-* headers are used for the remote IP address for rate
+				# limiting and for the "secure" status of cookies. (optional)
+				Forwarded: false
 
 			# All configured WebHandlers will serve on an enabled listener. (optional)
 			WebserverHTTP:

--- a/http/web.go
+++ b/http/web.go
@@ -821,7 +821,7 @@ func portServes(name string, l config.Listener) map[int]*serve {
 	}
 	if l.AutoconfigHTTPS.Enabled {
 		port := config.Port(l.AutoconfigHTTPS.Port, 443)
-		srv := ensureServe(!l.AutoconfigHTTPS.NonTLS, false, false, port, "autoconfig-https", false)
+		srv := ensureServe(!l.AutoconfigHTTPS.NonTLS, l.AutoconfigHTTPS.Enabled, false, port, "autoconfig-https", false)
 		if l.AutoconfigHTTPS.NonTLS {
 			ensureACMEHTTP01(srv)
 		}
@@ -851,7 +851,7 @@ func portServes(name string, l config.Listener) map[int]*serve {
 	}
 	if l.MTASTSHTTPS.Enabled {
 		port := config.Port(l.MTASTSHTTPS.Port, 443)
-		srv := ensureServe(!l.MTASTSHTTPS.NonTLS, false, false, port, "mtasts-https", false)
+		srv := ensureServe(!l.MTASTSHTTPS.NonTLS, l.MTASTSHTTPS.Forwarded, false, port, "mtasts-https", false)
 		if l.MTASTSHTTPS.NonTLS {
 			ensureACMEHTTP01(srv)
 		}


### PR DESCRIPTION
Currently, we log `http.Request#RemoteAddr` even when `Forwarded: true` is set. This isn't very useful (since in this configuration, the logged ip will probably just be localhost). Instead, respect the `X-Forwarded-For` header when `Forwarded: true` is set.

Additionally, allow `Forwarded: true` to be set for the autoconfig and mta-sts listeners. I didn't bother with the metrics listener, I think that one's fundamentally less interesting since it's not intended to be exposed to the outside world the way autoconfig is.

No tests - I couldn't see offhand that the logger is tested - but I'm running this on my local mox and it's doing the thing:

```
Aug 30 19:34:16 ur.gs mox[200532]: l=debug m="http request" pkg=http httpaccess= handler=admin method=get url=/mail/admin/ host=ur.gs duration="539.381µs" statuscode=200 proto=http/1.1 remoteaddr=10.0.1.181 tlsinfo=plain useragent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15" referer= size=62251 uncompressedsize=311815 cid=198fc40b091

Aug 30 19:35:03 ur.gs mox[200532]: l=debug m="http request" pkg=http httpaccess= handler=(nomatch) method=get url=/ host=mta-sts.ur.gs duration="34.305µs" statuscode=404 proto=http/1.1 remoteaddr=10.0.1.181 tlsinfo=plain useragent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15" referer= size=19 cid=198fc40b098

Aug 30 19:35:35 ur.gs mox[200532]: l=debug m="http request" pkg=http httpaccess= handler=(nomatch) method=get url=/favicon.ico host=autoconfig.ur.gs duration="81.263µs" statuscode=404 proto=http/1.1 remoteaddr=10.0.1.181 tlsinfo=plain useragent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/60.5 Safari/605.1.15" referer=https://autoconfig.ur.gs/ size=19 cid=198fc40b09c

```

Closes https://github.com/mjl-/mox/issues/369