### PR TITLE
Add a "Flagged" button to the webmail refine bar

### DIFF
--- a/webmail/webmail.js
+++ b/webmail/webmail.js
@@ -2186,6 +2186,10 @@ const refineFilters = (f, notf) => {
 		else if (refine === 'attachments') {
 			f.Attachments = 'any';
 		}
+		else if (refine === 'flagged') {
+			f.Labels = [...(f.Labels || [])];
+			f.Labels = (f.Labels || []).concat(['\\Flagged']);
+		}
 		else if (refine.startsWith('label:')) {
 			f.Labels = [...(f.Labels || [])];
 			f.Labels = (f.Labels || []).concat([refine.substring('label:'.length)]);
@@ -6503,9 +6507,9 @@ const init = async () => {
 	const activeMailbox = () => mailboxlistView.activeMailbox();
 	const msglistView = newMsglistView(msgElem, activeMailbox, listMailboxes, setLocationHash, otherMailbox, possibleLabels, () => msglistscrollElem ? msglistscrollElem.getBoundingClientRect().height : 0, refineKeyword, viewportEnsureMessages);
 	const mailboxlistView = newMailboxlistView(msglistView, requestNewView, updatePageTitle, setLocationHash, unloadSearch, otherMailbox);
-	let refineUnreadBtn, refineReadBtn, refineAttachmentsBtn, refineLabelBtn;
+	let refineUnreadBtn, refineReadBtn, refineAttachmentsBtn, refineFlaggedBtn, refineLabelBtn;
 	const refineToggleActive = (btn) => {
-		for (const e of [refineUnreadBtn, refineReadBtn, refineAttachmentsBtn, refineLabelBtn]) {
+		for (const e of [refineUnreadBtn, refineReadBtn, refineAttachmentsBtn, refineFlaggedBtn, refineLabelBtn]) {
 			e.classList.toggle('active', e === btn);
 		}
 		if (btn !== null && btn !== refineLabelBtn) {
@@ -6524,6 +6528,10 @@ const init = async () => {
 		await withStatus('Requesting messages', requestNewView(false));
 	}), refineAttachmentsBtn = dom.clickbutton(settings.refine === 'attachments' ? dom._class('active') : [], 'Attachments', attr.title('Only show messages with attachments.'), async function click(e) {
 		settingsPut({ ...settings, refine: 'attachments' });
+		refineToggleActive(e.target);
+		await withStatus('Requesting messages', requestNewView(false));
+	}), refineFlaggedBtn = dom.clickbutton(settings.refine === 'flagged' ? dom._class('active') : [], 'Flagged', attr.title('Only show flagged/starred messages.'), async function click(e) {
+		settingsPut({ ...settings, refine: 'flagged' });
 		refineToggleActive(e.target);
 		await withStatus('Requesting messages', requestNewView(false));
 	}), refineLabelBtn = dom.clickbutton(settings.refine.startsWith('label:') ? [dom._class('active'), 'Label: ' + settings.refine.substring('label:'.length)] : 'Label', attr.title('Only show messages with the selected label.'), async function click(e) {

--- a/webmail/webmail.ts
+++ b/webmail/webmail.ts
@@ -802,6 +802,9 @@ const refineFilters = (f: api.Filter, notf: api.NotFilter): [api.Filter, api.Not
 			f.Labels = (f.Labels || []).concat(['\\Seen'])
 		} else if (refine === 'attachments') {
 			f.Attachments = 'any' as api.AttachmentType
+		} else if (refine === 'flagged') {
+			f.Labels = [...(f.Labels || [])]
+			f.Labels = (f.Labels || []).concat(['\\Flagged'])
 		} else if (refine.startsWith('label:')) {
 			f.Labels = [...(f.Labels || [])]
 			f.Labels = (f.Labels || []).concat([refine.substring('label:'.length)])
@@ -6522,9 +6525,9 @@ const init = async () => {
 	const msglistView = newMsglistView(msgElem, activeMailbox, listMailboxes, setLocationHash, otherMailbox, possibleLabels, () => msglistscrollElem ? msglistscrollElem.getBoundingClientRect().height : 0, refineKeyword, viewportEnsureMessages)
 	const mailboxlistView = newMailboxlistView(msglistView, requestNewView, updatePageTitle, setLocationHash, unloadSearch, otherMailbox)
 
-	let refineUnreadBtn: HTMLButtonElement, refineReadBtn: HTMLButtonElement, refineAttachmentsBtn: HTMLButtonElement, refineLabelBtn: HTMLButtonElement
+	let refineUnreadBtn: HTMLButtonElement, refineReadBtn: HTMLButtonElement, refineAttachmentsBtn: HTMLButtonElement, refineFlaggedBtn: HTMLButtonElement, refineLabelBtn: HTMLButtonElement
 	const refineToggleActive = (btn: HTMLButtonElement | null): void => {
-		for (const e of [refineUnreadBtn, refineReadBtn, refineAttachmentsBtn, refineLabelBtn]) {
+		for (const e of [refineUnreadBtn, refineReadBtn, refineAttachmentsBtn, refineFlaggedBtn, refineLabelBtn]) {
 			e.classList.toggle('active', e === btn)
 		}
 		if (btn !== null && btn !== refineLabelBtn) {
@@ -6571,7 +6574,16 @@ const init = async () => {
 							await withStatus('Requesting messages', requestNewView(false))
 						},
 					),
-					refineLabelBtn=dom.clickbutton(settings.refine.startsWith('label:') ? [dom._class('active'), 'Label: '+settings.refine.substring('label:'.length)] : 'Label',
+					refineFlaggedBtn=dom.clickbutton(settings.refine === 'flagged' ? dom._class('active') : [],
+						'Flagged',
+						attr.title('Only show flagged/starred messages.'),
+						async function click(e: MouseEvent) {
+							settingsPut({...settings, refine: 'flagged'})
+							refineToggleActive(e.target! as HTMLButtonElement)
+							await withStatus('Requesting messages', requestNewView(false))
+						},
+					),
+				refineLabelBtn=dom.clickbutton(settings.refine.startsWith('label:') ? [dom._class('active'), 'Label: '+settings.refine.substring('label:'.length)] : 'Label',
 						attr.title('Only show messages with the selected label.'),
 						async function click(e: MouseEvent) {
 							const labels = possibleLabels()


### PR DESCRIPTION
Some users who have come from gmail environments are big users of the "star" or "flagged" (in IMAP Lingo) feature. I was finding it tricky to easily see what I have flagged (since for me those are normally the biz emails that cannot be answered immediately, so the flag list for me is a (sometimes huge) todo list)

This is my first PR against Mox, I tried to understand the jumbo webmail but it is entirely possible I have missed something here.

I am aware that I can search for "l:\Flagged" in webmail to do this but I think having a quick button is a huge win for people like me coming from gmail/gsuite/google workspace/whatever

I have deployed and tested this change (by applying it on top of v0.0.15) on my own instance and it seems to work fine