### PR TITLE
Restrict TLS cipher suites to GCM/CHACHA20 and bump Go to 1.26.3 for SHA-1 removal

### DIFF
--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -51,7 +51,7 @@ services:
       dns:
         condition: service_healthy
       acmepebble:
-        condition: service_healthy
+        condition: service_started
     networks:
       mailnet1:
         ipv4_address: 172.28.1.10
@@ -76,7 +76,7 @@ services:
       dns:
         condition: service_healthy
       acmepebble:
-        condition: service_healthy
+        condition: service_started
       # moxacmepebble creates tmp-pebble-ca.pem, needed by moxmail2 to trust the certificates offered by moxacmepebble.
       moxacmepebble:
         condition: service_healthy
@@ -104,7 +104,7 @@ services:
       dns:
         condition: service_healthy
       acmepebble:
-        condition: service_healthy
+        condition: service_started
     networks:
       mailnet1:
         ipv4_address: 172.28.1.80
@@ -180,19 +180,16 @@ services:
   # certificate in moxacmepebble and moxmail2.
   acmepebble:
     hostname: acmepebble.example
-    image: docker.io/letsencrypt/pebble:v2.3.1@sha256:fc5a537bf8fbc7cc63aa24ec3142283aa9b6ba54529f86eb8ff31fbde7c5b258
+    image: ghcr.io/letsencrypt/pebble:v2.6.0@sha256:18f6e3326ef8b307ce3e97a8c6f00613e318178450a684415e053507ed1f740f
     volumes:
       - ./testdata/integration/resolv.conf:/etc/resolv.conf:z
       - ./testdata/integration:/integration:z
-    command: ["sh", "-c", "set -ex; mount; ls -l /etc/resolv.conf; chmod o+r /etc/resolv.conf; pebble -config /integration/pebble-config.json"]
+    command: ["-config", "/integration/pebble-config.json"]
     ports:
       - 14000:14000  # ACME port
       - 15000:15000  # Management port
-    healthcheck:
-      test: netstat -nlt | grep ':14000 '
-      interval: 1s
-      timeout: 1s
-      retries: 10
+    # The distroless pebble image has no shell or netstat, so we can't run a
+    # netstat-based healthcheck. Dependents use service_started instead.
     depends_on:
       dns:
         condition: service_healthy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mjl-/mox
 
-go 1.24.0
+go 1.26.3
 
 require (
 	github.com/mjl-/adns v0.0.0-20250321173553-ab04b05bdfea

--- a/mox-/config.go
+++ b/mox-/config.go
@@ -837,14 +837,29 @@ func PrepareStaticConfig(ctx context.Context, log mlog.Log, configFile string, c
 				}
 				minVersion = v
 			}
+			// Only allow GCM and CHACHA20-POLY1305 cipher suites for TLS 1.2, excluding
+			// CBC-SHA suites that are considered insufficient by internet.nl/NCSC-NL
+			// guidelines. TLS 1.3 cipher suites are not configurable and always secure.
+			cipherSuites := []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+			}
+
 			if l.TLS.Config != nil {
 				l.TLS.Config.MinVersion = minVersion
+				l.TLS.Config.CipherSuites = cipherSuites
 			}
 			if l.TLS.ConfigFallback != nil {
 				l.TLS.ConfigFallback.MinVersion = minVersion
+				l.TLS.ConfigFallback.CipherSuites = cipherSuites
 			}
 			if l.TLS.ACMEConfig != nil {
 				l.TLS.ACMEConfig.MinVersion = minVersion
+				l.TLS.ACMEConfig.CipherSuites = cipherSuites
 			}
 		} else {
 			var needsTLS []string


### PR DESCRIPTION
Fixes #409.

## Summary

Internet.nl's mail-server check flagged my mox instance for two TLS issues that boil down to Go's default TLS 1.2 configuration:

1. **Insufficient cipher suites**: Go's default cipher list still includes `TLS_ECDHE_ECDSA_WITH_AES_{128,256}_CBC_SHA`, which NCSC-NL rates as insufficient (golang/go#13385 is open and unplanned).
2. **SHA-1 in key exchange**: Go's TLS 1.2 server advertised SHA-1 as a supported signature algorithm — fixed in Go 1.25 per RFC 9155 (golang/go#72883), can be re-enabled with `GODEBUG=tlssha1=1`.

### Changes

- **`mox-/config.go`**: Explicitly set `CipherSuites` on `Config`, `ConfigFallback`, and `ACMEConfig` (right where `MinVersion` is already set) to only allow GCM and CHACHA20-POLY1305 suites that NCSC-NL rates as Sufficient. TLS 1.3 cipher suites remain non-configurable in Go and are always secure.
- **`go.mod`**: Bump from `1.24.0` to `1.26.3` so the SHA-1 signature algorithm change from Go 1.25 takes effect.
- **`docker-compose-integration.yml`** *(separate commit)*: Pebble moved off Docker Hub, so the image reference is updated to `ghcr.io/letsencrypt/pebble`. Pinned to `v2.6.0` — newer pebble releases contain breaking changes for our integration setup. The v2.6.0 image is distroless (no shell, no netstat), so pebble args are passed directly instead of via `sh -c`, the netstat-based healthcheck is dropped, and dependents now wait via `service_started`.

### Allowed cipher suites after this change

```
TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
```

## Test plan

- [x] `go build ./...` succeeds with Go 1.26.3
- [x] Cross-compiled `GOOS=linux GOARCH=arm64 go build` and ran `./mox version` on Linux/aarch64
- [x] Re-ran https://internet.nl/mail/ against an instance built from this branch — 100% score, both "Cipher suites" and "Hash function for key exchange" subtests pass
- [x] `make test-integration` passes against the updated pebble image
- [x] Verified with a real test mail and a Thunderbird IMAP/SMTP connection — no client regressions

## Notes

Happy to split the pebble change into a separate PR if preferred. Also happy to make the cipher suite list configurable via the `TLS` config struct rather than hardcoded, if you'd like to give operators an escape hatch.