### PR TITLE
imapserver: emit a single untagged SEARCH response instead of chunking by 100

### DIFF
--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -493,38 +493,28 @@ func (c *conn) cmdxSearch(isUID, isE bool, tag, cmd string, p *parser) {
 		// We'll only have a result for the one selected mailbox.
 		result := results[0]
 
-		// In IMAP4rev1, an untagged SEARCH response is required. ../rfc/3501:2728
-		if len(result.UIDs) == 0 {
-			c.xbwritelinef("* SEARCH")
+		// Old-style SEARCH response: a single untagged line listing all matching
+		// numbers. RFC 3501 specifies one response; clients like emersion/go-imap
+		// (used by aerc) only retain the last untagged SEARCH response, so any
+		// split truncates the visible result set. See issue #389.
+		// ../rfc/3501:2728 ../rfc/3501:4833 ../rfc/9051:6809
+		var s strings.Builder
+		for _, v := range result.UIDs {
+			if !isUID {
+				v = store.UID(c.xsequence(v))
+			}
+			fmt.Fprintf(&s, " %d", v)
 		}
 
-		// Old-style SEARCH response. We must spell out each number. So we may be splitting
-		// into multiple responses. ../rfc/9051:6809 ../rfc/3501:4833
-		for len(result.UIDs) > 0 {
-			n := min(100, len(result.UIDs))
-			s := ""
-			for _, v := range result.UIDs[:n] {
-				if !isUID {
-					v = store.UID(c.xsequence(v))
-				}
-				s += " " + fmt.Sprintf("%d", v)
-			}
-
-			// Since we don't have the max modseq for the possibly partial uid range we're
-			// writing here within hand reach, we conveniently interpret the ambiguous "for all
-			// messages being returned" in ../rfc/7162:1107 as meaning over all lines that we
-			// write. And that clients only commit this value after they have seen the tagged
-			// end of the command. Appears to be recommended behaviour, ../rfc/7162:2323.
-			// ../rfc/7162:1077 ../rfc/7162:1101
-			var modseq string
-			if sk.hasModseq() {
-				// ../rfc/7162:2557
-				modseq = fmt.Sprintf(" (MODSEQ %d)", result.MaxModSeq.Client())
-			}
-
-			c.xbwritelinef("* SEARCH%s%s", s, modseq)
-			result.UIDs = result.UIDs[n:]
+		// MODSEQ is only attached when there were matches: RFC 7162 ties the
+		// returned modseq to "all messages being returned", so an empty result
+		// has nothing to attach it to. ../rfc/7162:1077 ../rfc/7162:1101
+		// ../rfc/7162:2323 ../rfc/7162:2557
+		var modseq string
+		if sk.hasModseq() && len(result.UIDs) > 0 {
+			modseq = fmt.Sprintf(" (MODSEQ %d)", result.MaxModSeq.Client())
 		}
+		c.xbwritelinef("* SEARCH%s%s", s.String(), modseq)
 	} else {
 		// New-style ESEARCH response syntax: ../rfc/9051:6546 ../rfc/4466:522
 

--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/textproto"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -493,38 +494,29 @@ func (c *conn) cmdxSearch(isUID, isE bool, tag, cmd string, p *parser) {
 		// We'll only have a result for the one selected mailbox.
 		result := results[0]
 
-		// In IMAP4rev1, an untagged SEARCH response is required. ../rfc/3501:2728
-		if len(result.UIDs) == 0 {
-			c.xbwritelinef("* SEARCH")
+		// Old-style SEARCH response: a single untagged line listing all matching
+		// numbers. RFC 3501 specifies one response; clients like emersion/go-imap
+		// (used by aerc) only retain the last untagged SEARCH response, so any
+		// split truncates the visible result set. See issue #389.
+		// ../rfc/3501:2728 ../rfc/3501:4833 ../rfc/9051:6809
+		var s strings.Builder
+		for _, v := range result.UIDs {
+			if !isUID {
+				v = store.UID(c.xsequence(v))
+			}
+			s.WriteString(" ")
+			s.WriteString(strconv.FormatUint(uint64(v), 10))
 		}
 
-		// Old-style SEARCH response. We must spell out each number. So we may be splitting
-		// into multiple responses. ../rfc/9051:6809 ../rfc/3501:4833
-		for len(result.UIDs) > 0 {
-			n := min(100, len(result.UIDs))
-			var s strings.Builder
-			for _, v := range result.UIDs[:n] {
-				if !isUID {
-					v = store.UID(c.xsequence(v))
-				}
-				s.WriteString(" " + fmt.Sprintf("%d", v))
-			}
-
-			// Since we don't have the max modseq for the possibly partial uid range we're
-			// writing here within hand reach, we conveniently interpret the ambiguous "for all
-			// messages being returned" in ../rfc/7162:1107 as meaning over all lines that we
-			// write. And that clients only commit this value after they have seen the tagged
-			// end of the command. Appears to be recommended behaviour, ../rfc/7162:2323.
-			// ../rfc/7162:1077 ../rfc/7162:1101
-			var modseq string
-			if sk.hasModseq() {
-				// ../rfc/7162:2557
-				modseq = fmt.Sprintf(" (MODSEQ %d)", result.MaxModSeq.Client())
-			}
-
-			c.xbwritelinef("* SEARCH%s%s", s.String(), modseq)
-			result.UIDs = result.UIDs[n:]
+		// MODSEQ is only attached when there were matches: RFC 7162 ties the
+		// returned modseq to "all messages being returned", so an empty result
+		// has nothing to attach it to. ../rfc/7162:1077 ../rfc/7162:1101
+		// ../rfc/7162:2323 ../rfc/7162:2557
+		var modseq string
+		if sk.hasModseq() && len(result.UIDs) > 0 {
+			modseq = fmt.Sprintf(" (MODSEQ %d)", result.MaxModSeq.Client())
 		}
+		c.xbwritelinef("* SEARCH%s%s", s.String(), modseq)
 	} else {
 		// New-style ESEARCH response syntax: ../rfc/9051:6546 ../rfc/4466:522
 

--- a/imapserver/search_test.go
+++ b/imapserver/search_test.go
@@ -854,3 +854,32 @@ func testSearchMulti(t *testing.T, selected, uidonly bool) {
 		imapclient.UntaggedEsearch{Tag: "Tag1", Mailbox: "Inbox", UIDValidity: 1, UID: true, All: esearchall0("5:8")},
 	)
 }
+
+// Red test for issue #389: mox must return a single untagged "* SEARCH ..."
+// response per (UID) SEARCH command, even when there are more than 100 matches.
+// RFC 3501 (../rfc/3501:2737) defines the untagged SEARCH response as one line
+// listing all matching numbers; clients like emersion/go-imap (used by aerc)
+// only retain the last response, so splitting truncates the visible mailbox.
+func TestSearchSingleResponse(t *testing.T) {
+	tc := start(t, false)
+	defer tc.close()
+	tc.login("mjl@mox.example", password0)
+	tc.client.Select("inbox")
+
+	// Append more than 100 messages to cross the chunking boundary in
+	// imapserver/search.go where results are emitted in groups of 100.
+	const n = 101
+	msgs := make([]imapclient.Append, n)
+	for i := range msgs {
+		msgs[i] = makeAppend(exampleMsg)
+	}
+	tc.client.MultiAppend("inbox", msgs[0], msgs[1:]...)
+
+	tc.transactf("ok", "uid search all")
+
+	expected := make([]uint32, n)
+	for i := range expected {
+		expected[i] = uint32(i + 1)
+	}
+	tc.xsearch(expected...)
+}


### PR DESCRIPTION
## Summary
- RFC 3501 specifies one untagged `* SEARCH` response per command, but mox was splitting results into multiple lines of 100 UIDs.
- Clients built on `emersion/go-imap` (e.g. aerc) only retain the last untagged SEARCH, so mailboxes with more than 100 matches appeared truncated. Fixes #389.
- Also collapses MODSEQ to a single emission per response, matching RFC 7162's "for all messages being returned" wording.

## Test plan
- [x] New `TestSearchSingleResponse` appends 101 messages and asserts a single `UntaggedSearch` event covering all UIDs (red against the old chunked code).
- [x] Existing search tests still pass.
- [x] Manual: ran a local mox server, sent 105 messages to `mox@localhost`, ran `UID SEARCH ALL` and confirmed a single `* SEARCH` line.