### PR TITLE
Fix integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ FROM alpine:latest
 WORKDIR /mox
 COPY --from=build /build/mox /bin/mox
 
-RUN apk add --no-cache tzdata
+ARG EXTRA_PACKAGES=""
+RUN apk add --no-cache tzdata ${EXTRA_PACKAGES}
 
 # SMTP for incoming message delivery.
 EXPOSE 25/tcp

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ modernize:
 test-integration:
 	-docker compose -f docker-compose-integration.yml kill
 	-docker compose -f docker-compose-integration.yml down
-	docker image build --pull --no-cache -f Dockerfile -t mox_integration_moxmail .
+	docker image build --pull --no-cache --build-arg EXTRA_PACKAGES="curl unbound" -f Dockerfile -t mox_integration_moxmail .
 	docker image build --pull --no-cache -f testdata/integration/Dockerfile.test -t mox_integration_test testdata/integration
 	-rm -rf testdata/integration/moxacmepebble/data
 	-rm -rf testdata/integration/moxmail2/data

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -6,7 +6,12 @@ services:
     # We add our cfssl-generated CA (which is in the repo) and acme pebble CA
     # (generated each time pebble starts) to the list of trusted CA's, so the TLS
     # dials in integration_test.go succeed.
-    command: ["sh", "-c", "set -ex; cat /integration/tmp-pebble-ca.pem /integration/tls/ca.pem >>/etc/ssl/certs/ca-certificates.crt; go test -tags integration"]
+    command:
+      [
+        "sh",
+        "-c",
+        "set -ex; cat /integration/tmp-pebble-ca.pem /integration/tls/ca.pem >>/etc/ssl/certs/ca-certificates.crt; go test -tags integration",
+      ]
     volumes:
       - ./.go:/.go:z
       - ./testdata/integration/resolv.conf:/etc/resolv.conf:z
@@ -51,7 +56,7 @@ services:
       dns:
         condition: service_healthy
       acmepebble:
-        condition: service_healthy
+        condition: service_started
     networks:
       mailnet1:
         ipv4_address: 172.28.1.10
@@ -76,7 +81,7 @@ services:
       dns:
         condition: service_healthy
       acmepebble:
-        condition: service_healthy
+        condition: service_started
       # moxacmepebble creates tmp-pebble-ca.pem, needed by moxmail2 to trust the certificates offered by moxacmepebble.
       moxacmepebble:
         condition: service_healthy
@@ -104,7 +109,7 @@ services:
       dns:
         condition: service_healthy
       acmepebble:
-        condition: service_healthy
+        condition: service_started
     networks:
       mailnet1:
         ipv4_address: 172.28.1.80
@@ -113,7 +118,12 @@ services:
     hostname: localserve.mox1.example
     domainname: mox1.example
     image: mox_integration_moxmail
-    command: ["sh", "-c", "set -e; chmod o+r /etc/resolv.conf; mox -checkconsistency localserve -ip 172.28.1.60"]
+    command:
+      [
+        "sh",
+        "-c",
+        "set -e; chmod o+r /etc/resolv.conf; mox -checkconsistency localserve -ip 172.28.1.60",
+      ]
     volumes:
       - ./.go:/.go:z
       - ./testdata/integration/resolv.conf:/etc/resolv.conf:z
@@ -141,7 +151,12 @@ services:
     volumes:
       # todo: figure out how to mount files with a uid that the process in the container can read...
       - ./testdata/integration/resolv.conf:/etc/resolv.conf:z
-    command: ["sh", "-c", "set -e; chmod o+r /etc/resolv.conf; (echo 'maillog_file = /dev/stdout'; echo 'mydestination = $$myhostname, localhost.$$mydomain, localhost, $$mydomain'; echo 'smtp_tls_security_level = may') >>/etc/postfix/main.cf; echo 'root: postfix@mox1.example' >>/etc/postfix/aliases; newaliases; postfix start-fg"]
+    command:
+      [
+        "sh",
+        "-c",
+        "set -e; chmod o+r /etc/resolv.conf; (echo 'maillog_file = /dev/stdout'; echo 'mydestination = $$myhostname, localhost.$$mydomain, localhost, $$mydomain'; echo 'smtp_tls_security_level = may') >>/etc/postfix/main.cf; echo 'root: postfix@mox1.example' >>/etc/postfix/aliases; newaliases; postfix start-fg",
+      ]
     healthcheck:
       test: netstat -nlt | grep ':25 '
       interval: 1s
@@ -165,7 +180,12 @@ services:
       - ./testdata/integration:/integration:z
     # We start with a base example.zone, but moxacmepebble appends its records,
     # followed by moxmail2. They restart unbound after appending records.
-    command: ["sh", "-c", "set -ex; ls -l /etc/resolv.conf; chmod o+r /etc/resolv.conf; install -m 640 -o unbound /integration/unbound.conf /etc/unbound/; chmod 755 /integration; chmod 644 /integration/*.zone; cp /integration/example.zone /integration/example-integration.zone; ls -ld /integration /integration/reverse.zone; unbound -d -p -v"]
+    command:
+      [
+        "sh",
+        "-c",
+        "set -ex; ls -l /etc/resolv.conf; chmod o+r /etc/resolv.conf; install -m 640 -o unbound /integration/unbound.conf /etc/unbound/; chmod 755 /integration; chmod 644 /integration/*.zone; cp /integration/example.zone /integration/example-integration.zone; ls -ld /integration /integration/reverse.zone; unbound -d -p -v",
+      ]
     healthcheck:
       test: netstat -nlu | grep '172.28.1.30:53 '
       interval: 1s
@@ -180,19 +200,32 @@ services:
   # certificate in moxacmepebble and moxmail2.
   acmepebble:
     hostname: acmepebble.example
-    image: docker.io/letsencrypt/pebble:v2.3.1@sha256:fc5a537bf8fbc7cc63aa24ec3142283aa9b6ba54529f86eb8ff31fbde7c5b258
+    # Pin to pebble v2.8.0. Newer versions (v2.9+) stopped setting a Location
+    # header on the finalize-order response, which is incompatible with the
+    # vendored golang.org/x/crypto/acme client used by mox: it then POSTs to
+    # an empty URL ("Post \"\": unsupported protocol scheme \"\"").
+    image: ghcr.io/letsencrypt/pebble:sha-d52948c
     volumes:
-      - ./testdata/integration/resolv.conf:/etc/resolv.conf:z
       - ./testdata/integration:/integration:z
-    command: ["sh", "-c", "set -ex; mount; ls -l /etc/resolv.conf; chmod o+r /etc/resolv.conf; pebble -config /integration/pebble-config.json"]
+    # The pebble image is distroless (no shell), so we pass args directly to
+    # the /app entrypoint. Use -dnsserver to point at the integration dns
+    # container instead of mounting a custom /etc/resolv.conf. No healthcheck
+    # is possible because the image has no utilities; dependents use
+    # service_started and retry connecting to :14000 in their startup scripts.
+    command:
+      [
+        "-config",
+        "/integration/pebble-config.json",
+        "-dnsserver",
+        "172.28.1.30:53",
+      ]
+    environment:
+      PEBBLE_VA_NOSLEEP: "1"
+      PEBBLE_WFE_NONCEREJECT: "0"
+      PEBBLE_AUTHZREUSE: "0"
     ports:
-      - 14000:14000  # ACME port
-      - 15000:15000  # Management port
-    healthcheck:
-      test: netstat -nlt | grep ':14000 '
-      interval: 1s
-      timeout: 1s
-      retries: 10
+      - 14000:14000 # ACME port
+      - 15000:15000 # Management port
     depends_on:
       dns:
         condition: service_healthy

--- a/testdata/integration/moxacmepebble.sh
+++ b/testdata/integration/moxacmepebble.sh
@@ -31,7 +31,7 @@ sed -i -e 's/moxtest1@mox1.example: nil/moxtest1@mox1.example: nil\n\t\t\tpostfi
 ) >/integration/example-integration.zone
 unbound-control -s 172.28.1.30 reload # reload unbound with zone file changes
 
-CURL_CA_BUNDLE=/integration/tls/ca.pem curl -o /integration/tmp-pebble-ca.pem https://acmepebble.example:15000/roots/0
+CURL_CA_BUNDLE=/integration/tls/ca.pem curl --retry 30 --retry-delay 1 --retry-connrefused -o /integration/tmp-pebble-ca.pem https://acmepebble.example:15000/roots/0
 
 mox -checkconsistency serve &
 while true; do

--- a/testdata/integration/moxacmepebble.sh
+++ b/testdata/integration/moxacmepebble.sh
@@ -2,8 +2,6 @@
 set -x # print commands
 set -e # exit on failed command
 
-apk add unbound curl
-
 (rm -r /tmp/mox 2>/dev/null || exit 0) # clean slate
 mkdir /tmp/mox
 cd /tmp/mox

--- a/testdata/integration/moxacmepebblealpn.sh
+++ b/testdata/integration/moxacmepebblealpn.sh
@@ -20,7 +20,7 @@ TLS:
 			- /integration/tls/ca.pem
 EOF
 
-CURL_CA_BUNDLE=/integration/tls/ca.pem curl -o /integration/tmp-pebble-ca.pem https://acmepebble.example:15000/roots/0
+CURL_CA_BUNDLE=/integration/tls/ca.pem curl --retry 30 --retry-delay 1 --retry-connrefused -o /integration/tmp-pebble-ca.pem https://acmepebble.example:15000/roots/0
 
 mox -checkconsistency serve &
 while true; do

--- a/testdata/integration/moxacmepebblealpn.sh
+++ b/testdata/integration/moxacmepebblealpn.sh
@@ -2,8 +2,6 @@
 set -x # print commands
 set -e # exit on failed command
 
-apk add curl
-
 (rm -r /tmp/mox 2>/dev/null || exit 0) # clean slate
 mkdir /tmp/mox
 cd /tmp/mox

--- a/testdata/integration/moxmail2.sh
+++ b/testdata/integration/moxmail2.sh
@@ -2,8 +2,6 @@
 set -x # print commands
 set -e # exit on failed command
 
-apk add unbound
-
 (rm -r /tmp/mox 2>/dev/null || exit 0) # clean slate
 mkdir /tmp/mox
 cd /tmp/mox


### PR DESCRIPTION
Having problems running `make test-integration`, I found that Pebble changed somewhat since last updates here. 

- The image is no longer on Docker Hub (which prompted me to fix this).
- It is now distoless, so no healthcheck with `netstat`
- There is a `-dnsserver` option, replacing the `resolve.conf` hack, so the `resolve.conf` is not useful for this image (Still used by the other images) and thus not mounted in any longer.
- curl retrieval of the certs have added retries, to compensate for the missing health check

 