### PR TITLE
Document Account method naming scheme for broadcast responsibility

### DIFF
--- a/store/account.go
+++ b/store/account.go
@@ -19,7 +19,21 @@ database.
 */
 package store
 
-// todo: make up a function naming scheme that indicates whether caller should broadcast changes.
+// Functions in this package use a consistent pattern for indicating whether the caller
+// must broadcast changes:
+//
+// - Functions that accept a *bstore.Tx parameter are low-level database operations.
+//   They modify data within a provided transaction and return changes. The caller is
+//   responsible for committing the transaction and calling BroadcastChanges() with
+//   the returned changes. These functions return changes as return values.
+//
+// - Functions that do NOT accept a *bstore.Tx parameter are higher-level operations.
+//   They manage their own database transactions, commit them, and handle broadcasting
+//   of changes internally. The caller does not need to broadcast changes.
+//
+// This pattern ensures clear separation of concerns: low-level functions delegate
+// broadcasting responsibility to their callers (allowing batch operations), while
+// high-level functions provide complete, self-contained operations.
 
 import (
 	"context"


### PR DESCRIPTION
Replace the TODO comment with clear documentation explaining the consistent pattern used throughout the Account type:
- Methods accepting *bstore.Tx are low-level operations where the caller must broadcast changes after committing the transaction
- Methods without *bstore.Tx are high-level operations that handle broadcasting internally

This makes it explicit to maintainers and API users which methods require external change broadcasting and which handle it themselves.


Claude-Session: https://claude.ai/code/session_01BpmSQS4VpPG95qrCdhFkNF