### PR TITLE
fix allowACMEHosts overwrite when multiple listeners share ACME provider

### DIFF
--- a/mox-/config.go
+++ b/mox-/config.go
@@ -311,13 +311,18 @@ func (c *Config) IsClientSettingsDomain(d dns.Domain) (is bool) {
 }
 
 func (c *Config) allowACMEHosts(log mlog.Log, checkACMEHosts bool) {
+	managerHosts := map[*autotls.Manager]map[dns.Domain]struct{}{}
+
 	for _, l := range c.Static.Listeners {
 		if l.TLS == nil || l.TLS.ACME == "" {
 			continue
 		}
 
 		m := c.Static.ACME[l.TLS.ACME].Manager
-		hostnames := map[dns.Domain]struct{}{}
+		if managerHosts[m] == nil {
+			managerHosts[m] = map[dns.Domain]struct{}{}
+		}
+		hostnames := managerHosts[m]
 
 		hostnames[c.Static.HostnameDomain] = struct{}{}
 		if l.HostnameDomain.ASCII != "" {
@@ -368,14 +373,18 @@ func (c *Config) allowACMEHosts(log mlog.Log, checkACMEHosts bool) {
 			}
 		}
 
-		public := c.Static.Listeners["public"]
-		ips := public.IPs
-		if len(public.NATIPs) > 0 {
-			ips = public.NATIPs
-		}
-		if public.IPsNATed {
-			ips = nil
-		}
+	}
+
+	public := c.Static.Listeners["public"]
+	ips := public.IPs
+	if len(public.NATIPs) > 0 {
+		ips = public.NATIPs
+	}
+	if public.IPsNATed {
+		ips = nil
+	}
+
+	for m, hostnames := range managerHosts {
 		m.SetAllowedHostnames(log, dns.StrictResolver{Pkg: "autotls", Log: log.Logger}, hostnames, ips, checkACMEHosts)
 	}
 }


### PR DESCRIPTION
When multiple listeners share the same ACME provider (e.g., a **proxy listener** for HTTPS web services and a **public listener** for SMTP/IMAP), `allowACMEHosts` in [mox-/config.go](https://github.com/mjl-/mox/blob/1a47ba33893e5297371a59b9b368287598d02086/mox-/config.go#L313) iterates listeners and calls `SetAllowedHostnames` for each one. Since `SetAllowedHostnames` does a full replacement (`m.hosts = hostnames`), the last listener's call overwrites hostnames from earlier listeners.

For example, with a config like this:

```conf
ACME:
	letsencrypt:
		DirectoryURL: https://acme-v02.api.letsencrypt.org/directory
		ContactEmail: postmaster@domain.tld

Listeners:
	proxy:
		IPs:
			- 127.0.0.1
		TLS:
			ACME: letsencrypt
		AutoconfigHTTPS:
			Enabled: true
			Port: 10443
		MTASTSHTTPS:
			Enabled: true
			Port: 10443
		WebserverHTTPS:
			Enabled: true
			Port: 10443

	public:
		IPs:
			- 203.0.113.1
		TLS:
			ACME: letsencrypt
		SMTP:
			Enabled: true
		Submissions:
			Enabled: true
		IMAPS:
			Enabled: true
```

The **proxy listener** accumulates `{mail.domain.tld, autoconfig.domain.tld, mta-sts.domain.tld}`, but the **public listener** calls `SetAllowedHostnames` with just `{mail.domain.tld}`, overwriting the expanded list. Certificate requests for `autoconfig.domain.tld` and `mta-sts.domain.tld` then fail with `host not in allowlist`.

The analogous code in `http/web.go` (`ensureManagerHosts` [at line 886](https://github.com/mjl-/mox/blob/1a47ba33893e5297371a59b9b368287598d02086/http/web.go#L886)) does not have this bug: it uses `ensureManagerHosts[m]` as a map reference across listeners, accumulating entries instead of replacing.

The fix follows the same pattern: accumulate hostnames per ACME manager across all listeners then call `SetAllowedHostnames` once per manager after the loop.