### PR TITLE
webmail: don't intercept cmd+key browser shortcuts

### DIFF
--- a/webmail/webmail.js
+++ b/webmail/webmail.js
@@ -5425,7 +5425,7 @@ const newMsglistView = (msgElem, activeMailbox, listMailboxes, setLocationHash, 
 				'p', 'P',
 				'u', 'U',
 			];
-			if (!e.altKey && moveKeys.includes(e.key)) {
+			if (!e.altKey && !e.metaKey && moveKeys.includes(e.key)) {
 				const moveclick = (index, clip) => {
 					if (clip && index < 0) {
 						index = 0;

--- a/webmail/webmail.ts
+++ b/webmail/webmail.ts
@@ -5034,7 +5034,7 @@ const newMsglistView = (msgElem: HTMLElement, activeMailbox: () => api.Mailbox |
 				'p', 'P',
 				'u', 'U',
 			]
-			if (!e.altKey && moveKeys.includes(e.key)) {
+			if (!e.altKey && !e.metaKey && moveKeys.includes(e.key)) {
 				const moveclick = (index: number, clip: boolean) => {
 					if (clip && index < 0) {
 						index = 0


### PR DESCRIPTION
Previously, the message-list key handler intercepted move keys (l for page down, etc.) and called preventDefault whenever alt wasn't held. On macOS, cmd+l (jump to address bar) gets swallowed, along with several others like cmd+u and cmd+p.

cmd/meta isn't used for any move action, so skip the move-key handler entirely when it's held and let the browser handle those keys.