### PR TITLE
scram: use hmac.Equal for proof and signature verification

### DIFF
--- a/scram/scram.go
+++ b/scram/scram.go
@@ -307,7 +307,7 @@ func (s *Server) Finish(clientFinal []byte, saltedPassword []byte) (serverFinal 
 
 	clientSig := hmac0(s.h, storedKey, authMsg)
 	xor(clientSig, clientKey) // Now clientProof.
-	if !bytes.Equal(clientSig, proof) {
+	if !hmac.Equal(clientSig, proof) {
 		return "e=" + string(ErrInvalidProof), ErrInvalidProof
 	}
 
@@ -490,7 +490,7 @@ func (c *Client) ServerFinal(serverFinal []byte) (rerr error) {
 
 	serverKey := hmac0(c.h, c.saltedPassword, "Server Key")
 	serverSig := hmac0(c.h, serverKey, c.authMessage)
-	if !bytes.Equal(verifier, serverSig) {
+	if !hmac.Equal(verifier, serverSig) {
 		return fmt.Errorf("incorrect server signature")
 	}
 	return nil


### PR DESCRIPTION
Switch two password-derived SCRAM authentication comparisons from `bytes.Equal` to the constant-time `hmac.Equal`:

* `Server.Finish`: compare the computed client proof with the received proof
* `Client.ServerFinal`: compare the received verifier with the computed server signature

Using a constant-time comparison is the safer and more idiomatic choice for such authentication values. No new import is needed because the package already uses `crypto/hmac`.

I do not believe this represents a practical vulnerability in the normal SCRAM protocol flow. Both values are specific to an authentication transcript containing fresh nonce material, which prevents a repeated-query timing attack. This is a defense-in-depth hardening change.

The channel-binding comparison is not touched because it is not a password-derived authenticator.

Tests pass:

```
go test ./scram/
```

_Found while testing a constant-time linter I am building._