### PR TITLE
message: refuse to parse multiple From headers

### DIFF
--- a/message/from.go
+++ b/message/from.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,13 +12,18 @@ import (
 	"github.com/mjl-/mox/smtp"
 )
 
+var (
+	errFromHeaders   = errors.New("missing or duplicate from header")
+	errFromAddresses = errors.New("from header does not have exactly one address")
+)
+
 // From extracts the address in the From-header.
 //
 // An RFC5322 message must have a From header.
 // In theory, multiple addresses may be present. In practice zero or multiple
 // From headers may be present. From returns an error if there is not exactly
-// one address. This address can be used for evaluating a DMARC policy against
-// SPF and DKIM results.
+// one From header with exactly one address. This address can be used for
+// evaluating a DMARC policy against SPF and DKIM results.
 func From(elog *slog.Logger, strict bool, r io.ReaderAt, p *Part) (raddr smtp.Address, envelope *Envelope, header textproto.MIMEHeader, rerr error) {
 	log := mlog.New("message", elog)
 
@@ -39,9 +45,18 @@ func From(elog *slog.Logger, strict bool, r io.ReaderAt, p *Part) (raddr smtp.Ad
 	if err != nil {
 		return raddr, nil, nil, fmt.Errorf("parsing message header: %v", err)
 	}
+	// A message must have exactly one From header. ../rfc/5322:1145
+	// Multiple From headers are only allowed by the obsolete syntax, which leaves
+	// their interpretation unspecified. ../rfc/5322:1993
+	// We would use the first, while DKIM signs the physically last instance
+	// (../rfc/6376:2320), so the header we evaluate DMARC against and the header
+	// covered by the signature need not be the same. Reject instead of picking.
+	if l := header.Values("From"); len(l) != 1 {
+		return raddr, nil, nil, fmt.Errorf("%w: %d headers", errFromHeaders, len(l))
+	}
 	from := p.Envelope.From
 	if len(from) != 1 {
-		return raddr, nil, nil, fmt.Errorf("from header has %d addresses, need exactly 1 address", len(from))
+		return raddr, nil, nil, fmt.Errorf("%w: %d addresses", errFromAddresses, len(from))
 	}
 	d, err := dns.ParseDomain(from[0].Host)
 	if err != nil {

--- a/message/from_test.go
+++ b/message/from_test.go
@@ -1,0 +1,32 @@
+package message
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFrom(t *testing.T) {
+	check := func(headers, expAddr string, expErr error) {
+		t.Helper()
+
+		msg := strings.ReplaceAll(headers, "\n", "\r\n") + "\r\nbody\r\n"
+		addr, _, _, err := From(pkglog.Logger, false, strings.NewReader(msg), nil)
+		tfail(t, err, expErr)
+		if expErr == nil {
+			tcompare(t, addr.String(), expAddr)
+		}
+	}
+
+	check("From: mjl@mox.example\n", "mjl@mox.example", nil)
+	check("From: Mechiel <mjl@mox.example>\n", "mjl@mox.example", nil)
+
+	// Exactly one from header, with exactly one address. ../rfc/5322:1145
+	check("Subject: test\n", "", errFromHeaders)
+	check("From: mjl@mox.example, other@mox.example\n", "", errFromAddresses)
+
+	// With multiple from headers we would use the first, while DKIM signs the last, so
+	// we reject. ../rfc/5322:1993 ../rfc/6376:2320
+	check("From: attacker@evil.example\nFrom: ceo@bank.example\n", "", errFromHeaders)
+	check("From: ceo@bank.example\nFrom: attacker@evil.example\n", "", errFromHeaders)
+	check("From: mjl@mox.example\nFrom: mjl@mox.example\n", "", errFromHeaders)
+}


### PR DESCRIPTION
An RFC5322 message has exactly one From header (../rfc/5322:1145). Multiple From headers are only allowed by the obsolete syntax, which explicitly leaves their interpretation unspecified (../rfc/5322:1993).

The check in From() counted addresses within a single header, so a message with two From headers passed. DKIM signs the last instance of a repeated header (../rfc/6376:2320). So a sender could get dmarc=pass with header.from of a domain they control, on a message with an additional unvalidated From header.