### PR TITLE
Fix AUTH parameter to MAIL FROM command

### DIFF
--- a/smtpserver/server.go
+++ b/smtpserver/server.go
@@ -1789,9 +1789,11 @@ func (c *conn) cmdMail(p *parser) {
 			// ../rfc/4954:704
 			// todo future: should we accept utf-8-addr-xtext if there is no smtputf8, and utf-8 if there is? need to find a spec ../rfc/6533:259
 			p.xtake("=")
-			p.xtake("<")
-			p.xtext()
-			p.xtake(">")
+			if p.take("<") {
+				p.xtake(">")
+			} else {
+				p.xtext()
+			}
 		case "SMTPUTF8":
 			// ../rfc/6531:213
 			c.smtputf8 = true


### PR DESCRIPTION
RFC4954 describes it as "AUTH=text" or "AUTH=<>".

From RFC4954:
   An example where the original identity of the sender is trusted and
   known:

   C: MAIL FROM:<e=mc2@example.com> AUTH=e+3Dmc2@example.com
   S: 250 OK

   One example where the identity of the sender is not trusted or is
   otherwise being suppressed by the client:

   C: MAIL FROM:<john+@example.org> AUTH=<>
   S: 250 OK

Fixes #460 