### PR TITLE
feat: inbounds proxy protocol v1/v2 support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -158,29 +158,34 @@ type Listener struct {
 
 		FirstTimeSenderDelay *time.Duration `sconf:"optional" sconf-doc:"Delay before accepting a message from a first-time sender for the destination account. Default: 15s."`
 
-		TLSSessionTicketsDisabled *bool `sconf:"optional" sconf-doc:"Override default setting for enabling TLS session tickets. Disabling session tickets may work around TLS interoperability issues."`
+		TLSSessionTicketsDisabled *bool          `sconf:"optional" sconf-doc:"Override default setting for enabling TLS session tickets. Disabling session tickets may work around TLS interoperability issues."`
+		ProxyProtocol             *ProxyProtocol `sconf:"optional" sconf-doc:"Require a PROXY protocol v1 or v2 header on the dedicated SMTP port. Only connections from TrustedProxies are accepted. HTTPS/ALPN is not affected."`
 
 		DNSBLZones []dns.Domain `sconf:"-"`
 	} `sconf:"optional"`
 	Submission struct {
 		Enabled           bool
-		Port              int  `sconf:"optional" sconf-doc:"Default 587."`
-		NoRequireSTARTTLS bool `sconf:"optional" sconf-doc:"Do not require STARTTLS. Since users must login, this means password may be sent without encryption. Not recommended."`
+		Port              int            `sconf:"optional" sconf-doc:"Default 587."`
+		NoRequireSTARTTLS bool           `sconf:"optional" sconf-doc:"Do not require STARTTLS. Since users must login, this means password may be sent without encryption. Not recommended."`
+		ProxyProtocol     *ProxyProtocol `sconf:"optional" sconf-doc:"Require a PROXY protocol v1 or v2 header on the dedicated Submission port. Only connections from TrustedProxies are accepted. HTTPS/ALPN is not affected."`
 	} `sconf:"optional" sconf-doc:"SMTP for submitting email, e.g. by email applications. Starts out in plain text, can be upgraded to TLS with the STARTTLS command. Prefer using Submissions which is always a TLS connection."`
 	Submissions struct {
 		Enabled        bool
-		Port           int  `sconf:"optional" sconf-doc:"Default 465."`
-		EnabledOnHTTPS bool `sconf:"optional" sconf-doc:"Additionally enable submission on HTTPS port 443 via TLS ALPN. TLS Application Layer Protocol Negotiation allows clients to request a specific protocol from the server as part of the TLS connection setup. When this setting is enabled and a client requests the 'smtp' protocol after TLS, it will be able to talk SMTP to Mox on port 443. This is meant to be useful as a censorship circumvention technique for Delta Chat."`
+		Port           int            `sconf:"optional" sconf-doc:"Default 465."`
+		EnabledOnHTTPS bool           `sconf:"optional" sconf-doc:"Additionally enable submission on HTTPS port 443 via TLS ALPN. TLS Application Layer Protocol Negotiation allows clients to request a specific protocol from the server as part of the TLS connection setup. When this setting is enabled and a client requests the 'smtp' protocol after TLS, it will be able to talk SMTP to Mox on port 443. This is meant to be useful as a censorship circumvention technique for Delta Chat."`
+		ProxyProtocol  *ProxyProtocol `sconf:"optional" sconf-doc:"Require a PROXY protocol v1 or v2 header on the dedicated Submissions port. Only connections from TrustedProxies are accepted. HTTPS/ALPN is not affected."`
 	} `sconf:"optional" sconf-doc:"SMTP over TLS for submitting email, by email applications. Requires a TLS config."`
 	IMAP struct {
 		Enabled           bool
-		Port              int  `sconf:"optional" sconf-doc:"Default 143."`
-		NoRequireSTARTTLS bool `sconf:"optional" sconf-doc:"Enable this only when the connection is otherwise encrypted (e.g. through a VPN)."`
+		Port              int            `sconf:"optional" sconf-doc:"Default 143."`
+		NoRequireSTARTTLS bool           `sconf:"optional" sconf-doc:"Enable this only when the connection is otherwise encrypted (e.g. through a VPN)."`
+		ProxyProtocol     *ProxyProtocol `sconf:"optional" sconf-doc:"Require a PROXY protocol v1 or v2 header on the dedicated IMAP port. Only connections from TrustedProxies are accepted. HTTPS/ALPN is not affected."`
 	} `sconf:"optional" sconf-doc:"IMAP for reading email, by email applications. Starts out in plain text, can be upgraded to TLS with the STARTTLS command. Prefer using IMAPS instead which is always a TLS connection."`
 	IMAPS struct {
 		Enabled        bool
-		Port           int  `sconf:"optional" sconf-doc:"Default 993."`
-		EnabledOnHTTPS bool `sconf:"optional" sconf-doc:"Additionally enable IMAP on HTTPS port 443 via TLS ALPN. TLS Application Layer Protocol Negotiation allows clients to request a specific protocol from the server as part of the TLS connection setup. When this setting is enabled and a client requests the 'imap' protocol after TLS, it will be able to talk IMAP to Mox on port 443. This is meant to be useful as a censorship circumvention technique for Delta Chat."`
+		Port           int            `sconf:"optional" sconf-doc:"Default 993."`
+		EnabledOnHTTPS bool           `sconf:"optional" sconf-doc:"Additionally enable IMAP on HTTPS port 443 via TLS ALPN. TLS Application Layer Protocol Negotiation allows clients to request a specific protocol from the server as part of the TLS connection setup. When this setting is enabled and a client requests the 'imap' protocol after TLS, it will be able to talk IMAP to Mox on port 443. This is meant to be useful as a censorship circumvention technique for Delta Chat."`
+		ProxyProtocol  *ProxyProtocol `sconf:"optional" sconf-doc:"Require a PROXY protocol v1 or v2 header on the dedicated IMAPS port. Only connections from TrustedProxies are accepted. HTTPS/ALPN is not affected."`
 	} `sconf:"optional" sconf-doc:"IMAP over TLS for reading email, by email applications. Requires a TLS config."`
 	AccountHTTP  WebService `sconf:"optional" sconf-doc:"Account web interface, for email users wanting to change their accounts, e.g. set new password, set new delivery rulesets. Default path is /."`
 	AccountHTTPS WebService `sconf:"optional" sconf-doc:"Account web interface listener like AccountHTTP, but for HTTPS. Requires a TLS config."`
@@ -220,6 +225,13 @@ type Listener struct {
 		Port              int  `sconf:"optional" sconf-doc:"Port for HTTPS webserver."`
 		RateLimitDisabled bool `sconf:"optional" sconf-doc:"Disable rate limiting for all requests to this port."`
 	} `sconf:"optional" sconf-doc:"All configured WebHandlers will serve on an enabled listener. Either ACME must be configured, or for each WebHandler domain a TLS certificate must be configured."`
+}
+
+// ProxyProtocol configures strict PROXY protocol handling for one dedicated
+// SMTP or IMAP TCP port.
+type ProxyProtocol struct {
+	TrustedProxies   []string     `sconf:"optional" sconf-doc:"IP addresses or CIDR networks of proxies allowed to send PROXY protocol headers. At least one is required."`
+	TrustedProxyNets []*net.IPNet `sconf:"-" json:"-"`
 }
 
 // WebService is an internal web interface: webmail, webaccount, webadmin, webapi.

--- a/config/doc.go
+++ b/config/doc.go
@@ -271,6 +271,16 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# tickets may work around TLS interoperability issues. (optional)
 				TLSSessionTicketsDisabled: false
 
+				# Require a PROXY protocol v1 or v2 header on the dedicated SMTP port. Only
+				# connections from TrustedProxies are accepted. HTTPS/ALPN is not affected.
+				# (optional)
+				ProxyProtocol:
+
+					# IP addresses or CIDR networks of proxies allowed to send PROXY protocol headers.
+					# At least one is required. (optional)
+					TrustedProxies:
+						-
+
 			# SMTP for submitting email, e.g. by email applications. Starts out in plain text,
 			# can be upgraded to TLS with the STARTTLS command. Prefer using Submissions which
 			# is always a TLS connection. (optional)
@@ -283,6 +293,16 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# Do not require STARTTLS. Since users must login, this means password may be sent
 				# without encryption. Not recommended. (optional)
 				NoRequireSTARTTLS: false
+
+				# Require a PROXY protocol v1 or v2 header on the dedicated Submission port. Only
+				# connections from TrustedProxies are accepted. HTTPS/ALPN is not affected.
+				# (optional)
+				ProxyProtocol:
+
+					# IP addresses or CIDR networks of proxies allowed to send PROXY protocol headers.
+					# At least one is required. (optional)
+					TrustedProxies:
+						-
 
 			# SMTP over TLS for submitting email, by email applications. Requires a TLS
 			# config. (optional)
@@ -300,6 +320,16 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# technique for Delta Chat. (optional)
 				EnabledOnHTTPS: false
 
+				# Require a PROXY protocol v1 or v2 header on the dedicated Submissions port. Only
+				# connections from TrustedProxies are accepted. HTTPS/ALPN is not affected.
+				# (optional)
+				ProxyProtocol:
+
+					# IP addresses or CIDR networks of proxies allowed to send PROXY protocol headers.
+					# At least one is required. (optional)
+					TrustedProxies:
+						-
+
 			# IMAP for reading email, by email applications. Starts out in plain text, can be
 			# upgraded to TLS with the STARTTLS command. Prefer using IMAPS instead which is
 			# always a TLS connection. (optional)
@@ -312,6 +342,16 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# Enable this only when the connection is otherwise encrypted (e.g. through a
 				# VPN). (optional)
 				NoRequireSTARTTLS: false
+
+				# Require a PROXY protocol v1 or v2 header on the dedicated IMAP port. Only
+				# connections from TrustedProxies are accepted. HTTPS/ALPN is not affected.
+				# (optional)
+				ProxyProtocol:
+
+					# IP addresses or CIDR networks of proxies allowed to send PROXY protocol headers.
+					# At least one is required. (optional)
+					TrustedProxies:
+						-
 
 			# IMAP over TLS for reading email, by email applications. Requires a TLS config.
 			# (optional)
@@ -328,6 +368,16 @@ See https://pkg.go.dev/github.com/mjl-/sconf for details.
 				# Mox on port 443. This is meant to be useful as a censorship circumvention
 				# technique for Delta Chat. (optional)
 				EnabledOnHTTPS: false
+
+				# Require a PROXY protocol v1 or v2 header on the dedicated IMAPS port. Only
+				# connections from TrustedProxies are accepted. HTTPS/ALPN is not affected.
+				# (optional)
+				ProxyProtocol:
+
+					# IP addresses or CIDR networks of proxies allowed to send PROXY protocol headers.
+					# At least one is required. (optional)
+					TrustedProxies:
+						-
 
 			# Account web interface, for email users wanting to change their accounts, e.g.
 			# set new password, set new delivery rulesets. Default path is /. (optional)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mjl-/sherpadoc v0.0.18
 	github.com/mjl-/sherpaprom v0.0.2
 	github.com/prometheus/client_golang v1.18.0
+	github.com/pires/go-proxyproto v0.15.0
 	github.com/russross/blackfriday/v2 v2.1.0
 	go.etcd.io/bbolt v1.3.12
 	golang.org/x/crypto v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/mjl-/sherpats v0.0.6/go.mod h1:MoNZJtLmu8oCZ4Ocv5vZksENN4pp6/SJMlg9uT
 github.com/mjl-/xfmt v0.0.2 h1:6dLgd6U3bmDJKtTxsaSYYyMaORoO4hKBAJo4XKkPRko=
 github.com/mjl-/xfmt v0.0.2/go.mod h1:DIEOLmETMQHHr4OgwPG7iC37rDiN9MaZIZxNm5hBtL8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/pires/go-proxyproto v0.15.0 h1:dTshmNbFm/D+0+sbrxUuddPOZ5Y0B7c5NhtsBkm6LqI=
+github.com/pires/go-proxyproto v0.15.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/imapserver/proxyprotocol_test.go
+++ b/imapserver/proxyprotocol_test.go
@@ -1,0 +1,71 @@
+package imapserver
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mjl-/mox/config"
+	"github.com/mjl-/mox/mox-"
+)
+
+type imapProxyAddrConn struct {
+	net.Conn
+	local, remote net.Addr
+}
+
+func (c imapProxyAddrConn) LocalAddr() net.Addr  { return c.local }
+func (c imapProxyAddrConn) RemoteAddr() net.Addr { return c.remote }
+
+func TestProxyProtocolIMAP(t *testing.T) {
+	mox.Shutdown, mox.ShutdownCancel = context.WithCancel(context.Background())
+	mox.Context, mox.ContextCancel = context.WithCancel(context.Background())
+
+	pp := &config.ProxyProtocol{
+		TrustedProxyNets: []*net.IPNet{{IP: net.ParseIP("192.0.2.0").To4(), Mask: net.CIDRMask(24, 32)}},
+	}
+	test := func(name string, header []byte, expectGreeting bool) {
+		t.Run(name, func(t *testing.T) {
+			server, client := net.Pipe()
+			serverConn := imapProxyAddrConn{
+				Conn:   server,
+				local:  &net.TCPAddr{IP: net.ParseIP("198.51.100.2"), Port: 993},
+				remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 1000},
+			}
+			done := make(chan struct{})
+			go func() {
+				serve("test", 1, nil, serverConn, false, false, true, false, "", pp)
+				close(done)
+			}()
+
+			if _, err := client.Write(header); err != nil && expectGreeting {
+				t.Fatal(err)
+			}
+			var conn net.Conn = client
+			client.SetReadDeadline(time.Now().Add(time.Second))
+			line, err := bufio.NewReader(conn).ReadString('\n')
+			if expectGreeting {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.HasPrefix(line, "* OK ") {
+					t.Fatalf("got greeting %q", line)
+				}
+			} else if err == nil {
+				t.Fatalf("got unexpected greeting %q", line)
+			}
+			client.Close()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("IMAP server did not close")
+			}
+		})
+	}
+
+	test("v1", []byte("PROXY TCP4 203.0.113.4 198.51.100.2 1234 143\r\n"), true)
+	test("missing-header", []byte("A001 NOOP\r\n"), false)
+}

--- a/imapserver/server.go
+++ b/imapserver/server.go
@@ -75,6 +75,7 @@ import (
 	"github.com/mjl-/mox/mox-"
 	"github.com/mjl-/mox/moxio"
 	"github.com/mjl-/mox/moxvar"
+	"github.com/mjl-/mox/proxyprotocol"
 	"github.com/mjl-/mox/ratelimit"
 	"github.com/mjl-/mox/scram"
 	"github.com/mjl-/mox/store"
@@ -396,14 +397,14 @@ func Listen() {
 		if listener.IMAP.Enabled {
 			port := config.Port(listener.IMAP.Port, 143)
 			for _, ip := range listener.IPs {
-				listen1("imap", name, ip, port, tlsConfig, false, noTLSClientAuth, listener.IMAP.NoRequireSTARTTLS)
+				listen1("imap", name, ip, port, tlsConfig, false, noTLSClientAuth, listener.IMAP.NoRequireSTARTTLS, listener.IMAP.ProxyProtocol)
 			}
 		}
 
 		if listener.IMAPS.Enabled {
 			port := config.Port(listener.IMAPS.Port, 993)
 			for _, ip := range listener.IPs {
-				listen1("imaps", name, ip, port, tlsConfig, true, noTLSClientAuth, false)
+				listen1("imaps", name, ip, port, tlsConfig, true, noTLSClientAuth, false, listener.IMAPS.ProxyProtocol)
 			}
 		}
 	}
@@ -411,7 +412,7 @@ func Listen() {
 
 var servers []func()
 
-func listen1(protocol, listenerName, ip string, port int, tlsConfig *tls.Config, xtls, noTLSClientAuth, noRequireSTARTTLS bool) {
+func listen1(protocol, listenerName, ip string, port int, tlsConfig *tls.Config, xtls, noTLSClientAuth, noRequireSTARTTLS bool, proxyConfig *config.ProxyProtocol) {
 	log := mlog.New("imapserver", nil)
 	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
 	if os.Getuid() == 0 {
@@ -444,7 +445,7 @@ func listen1(protocol, listenerName, ip string, port int, tlsConfig *tls.Config,
 			}
 
 			metricIMAPConnection.WithLabelValues(protocol).Inc()
-			go serve(listenerName, mox.Cid(), tlsConfig, conn, xtls, noTLSClientAuth, noRequireSTARTTLS, false, "")
+			go serve(listenerName, mox.Cid(), tlsConfig, conn, xtls, noTLSClientAuth, noRequireSTARTTLS, false, "", proxyConfig)
 		}
 	}
 
@@ -771,7 +772,26 @@ var cleanClose struct{} // Sentinel value for panic/recover indicating clean clo
 // preauthenticated.
 //
 // The connection is closed before returning.
-func serve(listenerName string, cid int64, tlsConfig *tls.Config, nc net.Conn, xtls, noTLSClientAuth, noRequireSTARTTLS, viaHTTPS bool, preauthAddress string) {
+func serve(listenerName string, cid int64, tlsConfig *tls.Config, nc net.Conn, xtls, noTLSClientAuth, noRequireSTARTTLS, viaHTTPS bool, preauthAddress string, proxyConfigs ...*config.ProxyProtocol) {
+	proxyConfig := (*config.ProxyProtocol)(nil)
+	if len(proxyConfigs) > 0 {
+		proxyConfig = proxyConfigs[0]
+	}
+	rawConn := nc
+	mox.Connections.Register(rawConn, "imap", listenerName)
+	defer mox.Connections.Unregister(rawConn)
+	if proxyConfig != nil {
+		conn, err := proxyprotocol.NewConn(rawConn, proxyConfig.TrustedProxyNets)
+		if err != nil {
+			log := mlog.New("imapserver", nil)
+			log.Infox("imap: proxy protocol", err, slog.String("listener", listenerName), slog.Any("remote", rawConn.RemoteAddr()))
+			if err := rawConn.Close(); err != nil {
+				log.Debugx("imap: closing proxy protocol connection", err, slog.String("listener", listenerName))
+			}
+			return
+		}
+		nc = conn
+	}
 	var remoteIP net.IP
 	if a, ok := nc.RemoteAddr().(*net.TCPAddr); ok {
 		remoteIP = a.IP
@@ -819,7 +839,7 @@ func serve(listenerName string, cid int64, tlsConfig *tls.Config, nc net.Conn, x
 	// Many IMAP connections use IDLE to wait for new incoming messages. We'll enable
 	// keepalive to get a higher chance of the connection staying alive, or otherwise
 	// detecting broken connections early.
-	tcpconn := c.conn
+	tcpconn := rawConn
 	if viaHTTPS {
 		tcpconn = nc.(*tls.Conn).NetConn()
 	}
@@ -902,11 +922,6 @@ func serve(listenerName string, cid int64, tlsConfig *tls.Config, nc net.Conn, x
 		return
 	}
 	defer limiterConnections.Add(c.remoteIP, time.Now(), -1)
-
-	// We register and unregister the original connection, in case it c.conn is
-	// replaced with a TLS connection later on.
-	mox.Connections.Register(nc, "imap", listenerName)
-	defer mox.Connections.Unregister(nc)
 
 	if preauthAddress != "" {
 		acc, _, _, err := store.OpenEmail(c.log, preauthAddress, false)

--- a/licenses/github.com/pires/go-proxyproto/LICENSE
+++ b/licenses/github.com/pires/go-proxyproto/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Paulo Pires
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mox-/config.go
+++ b/mox-/config.go
@@ -748,6 +748,38 @@ func PrepareStaticConfig(ctx context.Context, log mlog.Log, configFile string, c
 		addListenerErrorf := func(format string, args ...any) {
 			addErrorf("listener %s: %w", name, fmt.Errorf(format, args...))
 		}
+		parseProxyProtocol := func(kind string, pp *config.ProxyProtocol) {
+			if pp == nil {
+				return
+			}
+			pp.TrustedProxyNets = nil
+			if len(pp.TrustedProxies) == 0 {
+				addListenerErrorf("%s ProxyProtocol requires at least one TrustedProxies entry", kind)
+				return
+			}
+			for _, s := range pp.TrustedProxies {
+				var network *net.IPNet
+				if ip := net.ParseIP(s); ip != nil {
+					if ip4 := ip.To4(); ip4 != nil {
+						network = &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)}
+					} else {
+						network = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+					}
+				} else {
+					_, network, _ = net.ParseCIDR(s)
+					if network == nil {
+						addListenerErrorf("%s ProxyProtocol TrustedProxies entry %q is not an IP address or CIDR", kind, s)
+						continue
+					}
+				}
+				pp.TrustedProxyNets = append(pp.TrustedProxyNets, network)
+			}
+		}
+		parseProxyProtocol("SMTP", l.SMTP.ProxyProtocol)
+		parseProxyProtocol("Submission", l.Submission.ProxyProtocol)
+		parseProxyProtocol("Submissions", l.Submissions.ProxyProtocol)
+		parseProxyProtocol("IMAP", l.IMAP.ProxyProtocol)
+		parseProxyProtocol("IMAPS", l.IMAPS.ProxyProtocol)
 
 		if l.Hostname != "" {
 			d, err := dns.ParseDomain(l.Hostname)

--- a/proxyprotocol/proxyprotocol.go
+++ b/proxyprotocol/proxyprotocol.go
@@ -1,0 +1,117 @@
+// Package proxyprotocol adapts the PROXY protocol implementation from
+// github.com/pires/go-proxyproto to Mox's listener policy.
+package proxyprotocol
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	proxyproto "github.com/pires/go-proxyproto"
+)
+
+const headerTimeout = 30 * time.Second
+
+// Conn is a connection with the source and destination addresses supplied by a
+// PROXY header. All other operations, including closing and deadlines, are
+// delegated to the underlying connection.
+type Conn struct {
+	net.Conn
+	reader     *bufio.Reader
+	remoteAddr net.Addr
+	localAddr  net.Addr
+}
+
+// Read first drains bytes already buffered while parsing the PROXY header,
+// then reads directly from the underlying connection.
+func (c *Conn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+// RemoteAddr returns the source address from the PROXY header.
+func (c *Conn) RemoteAddr() net.Addr { return c.remoteAddr }
+
+// LocalAddr returns the destination address from the PROXY header.
+func (c *Conn) LocalAddr() net.Addr { return c.localAddr }
+
+// NewConn verifies the underlying peer against trustedProxies, reads one
+// required PROXY protocol v1 or v2 header, and returns a connection that reports
+// the addresses from that header. The header is consumed exactly; following
+// application data remains available from the returned connection.
+//
+// A valid v1 UNKNOWN or v2 LOCAL header is accepted and leaves the underlying
+// connection addresses unchanged. Only TCP over IPv4 and IPv6 is accepted;
+// TLVs are parsed by the external library but not interpreted by Mox.
+func NewConn(conn net.Conn, trustedProxies []*net.IPNet) (*Conn, error) {
+	peerIP, err := addrIP(conn.RemoteAddr())
+	if err != nil {
+		return nil, fmt.Errorf("get proxy peer address: %w", err)
+	}
+	trusted := false
+	for _, network := range trustedProxies {
+		if network != nil && network.Contains(peerIP) {
+			trusted = true
+			break
+		}
+	}
+	if !trusted {
+		return nil, fmt.Errorf("proxy peer %s is not trusted", peerIP)
+	}
+
+	reader := bufio.NewReader(conn)
+	header, err := proxyproto.ReadHeaderTimeout(conn, reader, headerTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("read proxy header: %w", err)
+	}
+	if err := validateHeader(header); err != nil {
+		return nil, err
+	}
+
+	remoteAddr, localAddr := conn.RemoteAddr(), conn.LocalAddr()
+	if !header.Command.IsLocal() {
+		remoteAddr, localAddr, _ = header.TCPAddrs()
+	}
+	return &Conn{Conn: conn, reader: reader, remoteAddr: remoteAddr, localAddr: localAddr}, nil
+}
+
+func validateHeader(header *proxyproto.Header) error {
+	if header == nil {
+		return errors.New("proxy header is missing")
+	}
+
+	// UNKNOWN (v1) and LOCAL (v2) carry no client address. The external parser
+	// represents both as LOCAL, and Mox intentionally keeps the socket addresses.
+	if header.Command.IsLocal() {
+		switch header.TransportProtocol {
+		case proxyproto.UNSPEC, proxyproto.TCPv4, proxyproto.TCPv6:
+			return nil
+		default:
+			return fmt.Errorf("unsupported local proxy protocol %d", header.TransportProtocol)
+		}
+	}
+
+	if header.TransportProtocol != proxyproto.TCPv4 && header.TransportProtocol != proxyproto.TCPv6 {
+		return fmt.Errorf("unsupported proxy protocol %d", header.TransportProtocol)
+	}
+	if _, _, ok := header.TCPAddrs(); !ok {
+		return errors.New("proxy header has no TCP addresses")
+	}
+	return nil
+}
+
+func addrIP(addr net.Addr) (net.IP, error) {
+	if a, ok := addr.(*net.TCPAddr); ok && a.IP != nil {
+		return a.IP, nil
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return nil, fmt.Errorf("parse %q: %w", addr, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP %q", host)
+	}
+	return ip, nil
+}

--- a/proxyprotocol/proxyprotocol_test.go
+++ b/proxyprotocol/proxyprotocol_test.go
@@ -1,0 +1,161 @@
+package proxyprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+)
+
+type addrConn struct {
+	net.Conn
+	local, remote net.Addr
+}
+
+func (c addrConn) LocalAddr() net.Addr  { return c.local }
+func (c addrConn) RemoteAddr() net.Addr { return c.remote }
+
+var (
+	trustedLocal   = &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 1000}
+	trustedNetwork = &net.IPNet{IP: net.ParseIP("192.0.2.0").To4(), Mask: net.CIDRMask(24, 32)}
+)
+
+const maxV1Header = 108
+
+var v2Signature = [...]byte{13, 10, 13, 10, 0, 13, 10, 81, 85, 73, 84, 10}
+
+func run(t *testing.T, input []byte) (*Conn, net.Conn, error) {
+	t.Helper()
+	server, client := net.Pipe()
+	serverConn := addrConn{Conn: server, local: &net.TCPAddr{IP: net.ParseIP("198.51.100.2"), Port: 25}, remote: trustedLocal}
+	go func() {
+		_, _ = client.Write(input)
+		_ = client.Close()
+	}()
+	conn, clientConn, err := func() (*Conn, net.Conn, error) {
+		c, err := NewConn(serverConn, []*net.IPNet{trustedNetwork})
+		return c, client, err
+	}()
+	if err != nil {
+		_ = client.Close()
+	}
+	return conn, clientConn, err
+}
+
+func TestV1(t *testing.T) {
+	conn, client, err := run(t, []byte("PROXY TCP4 203.0.113.4 198.51.100.2 1234 25\r\nhello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if got := conn.RemoteAddr().String(); got != "203.0.113.4:1234" {
+		t.Fatalf("remote address %s", got)
+	}
+	if got := conn.LocalAddr().String(); got != "198.51.100.2:25" {
+		t.Fatalf("local address %s", got)
+	}
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(conn, buf); err != nil || string(buf) != "hello" {
+		t.Fatalf("application data %q, %v", buf, err)
+	}
+}
+
+func TestV1IPv6AndUnknown(t *testing.T) {
+	conn, client, err := run(t, []byte("PROXY TCP6 2001:db8::4 2001:db8::5 1234 993\r\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	if got := conn.RemoteAddr().String(); got != "[2001:db8::4]:1234" {
+		t.Fatalf("remote address %s", got)
+	}
+
+	conn, client, err = run(t, []byte("PROXY UNKNOWN\r\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	if got := conn.RemoteAddr().String(); got != trustedLocal.String() {
+		t.Fatalf("unknown remote address %s", got)
+	}
+}
+
+func v2Header(command, family, protocol byte, payload []byte) []byte {
+	b := make([]byte, 16+len(payload))
+	copy(b, v2Signature[:])
+	b[12] = 2<<4 | command
+	b[13] = family<<4 | protocol
+	binary.BigEndian.PutUint16(b[14:16], uint16(len(payload)))
+	copy(b[16:], payload)
+	return b
+}
+
+func TestV2(t *testing.T) {
+	payload := make([]byte, 12)
+	copy(payload, net.ParseIP("203.0.113.8").To4())
+	copy(payload[4:], net.ParseIP("198.51.100.8").To4())
+	binary.BigEndian.PutUint16(payload[8:], 4321)
+	binary.BigEndian.PutUint16(payload[10:], 465)
+	conn, client, err := run(t, append(v2Header(1, 1, 1, payload), []byte("data")...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if got := conn.RemoteAddr().String(); got != "203.0.113.8:4321" {
+		t.Fatalf("remote address %s", got)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil || string(buf) != "data" {
+		t.Fatalf("application data %q, %v", buf, err)
+	}
+
+	conn, client, err = run(t, v2Header(0, 0, 0, []byte("ignored")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	if got := conn.RemoteAddr().String(); got != trustedLocal.String() {
+		t.Fatalf("local remote address %s", got)
+	}
+}
+
+func TestV2IPv6AndTLV(t *testing.T) {
+	payload := make([]byte, 36+3)
+	copy(payload, net.ParseIP("2001:db8::8"))
+	copy(payload[16:], net.ParseIP("2001:db8::9"))
+	binary.BigEndian.PutUint16(payload[32:], 993)
+	binary.BigEndian.PutUint16(payload[34:], 1993)
+	copy(payload[36:], []byte{1, 1, 0})
+	conn, client, err := run(t, v2Header(1, 2, 1, payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	if got := conn.LocalAddr().String(); got != "[2001:db8::9]:1993" {
+		t.Fatalf("local address %s", got)
+	}
+}
+
+func TestRejectsUntrustedAndMalformed(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+	conn := addrConn{Conn: server, local: trustedLocal, remote: &net.TCPAddr{IP: net.ParseIP("198.51.100.10"), Port: 1000}}
+	if _, err := NewConn(conn, []*net.IPNet{trustedNetwork}); err == nil {
+		t.Fatal("untrusted peer accepted")
+	}
+
+	for _, input := range [][]byte{
+		[]byte("HELO example\r\n"),
+		[]byte("PROXY TCP4 203.0.113.1 198.51.100.1 1 25\n"),
+		bytes.Repeat([]byte("x"), maxV1Header+1),
+		v2Header(1, 3, 1, make([]byte, 12)),
+		v2Header(1, 1, 2, make([]byte, 12)),
+		v2Header(1, 1, 1, make([]byte, 11)),
+	} {
+		_, _, err := run(t, input)
+		if err == nil {
+			t.Errorf("accepted malformed header %q", input)
+		}
+	}
+}

--- a/smtpserver/proxyprotocol_test.go
+++ b/smtpserver/proxyprotocol_test.go
@@ -1,0 +1,75 @@
+package smtpserver
+
+import (
+	"bufio"
+	"crypto/tls"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mjl-/mox/config"
+	"github.com/mjl-/mox/dns"
+)
+
+type proxyAddrConn struct {
+	net.Conn
+	local, remote net.Addr
+}
+
+func (c proxyAddrConn) LocalAddr() net.Addr  { return c.local }
+func (c proxyAddrConn) RemoteAddr() net.Addr { return c.remote }
+
+func smtpProxyConfig() *config.ProxyProtocol {
+	return &config.ProxyProtocol{
+		TrustedProxyNets: []*net.IPNet{{IP: net.ParseIP("192.0.2.0").To4(), Mask: net.CIDRMask(24, 32)}},
+	}
+}
+
+func TestProxyProtocolSMTP(t *testing.T) {
+	ts := newTestServer(t, "../testdata/smtp/mox.conf", dns.MockResolver{})
+	defer ts.close()
+
+	test := func(name string, header []byte, immediateTLS bool) {
+		t.Run(name, func(t *testing.T) {
+			server, client := net.Pipe()
+			serverConn := proxyAddrConn{
+				Conn:   server,
+				local:  &net.TCPAddr{IP: net.ParseIP("198.51.100.2"), Port: 465},
+				remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 1000},
+			}
+			done := make(chan struct{})
+			go func() {
+				serve("test", ts.cid, dns.Domain{ASCII: "mox.example"}, ts.serverConfig, serverConn, ts.resolver, immediateTLS, immediateTLS, false, false, 100<<20, immediateTLS, immediateTLS, false, nil, 0, smtpProxyConfig())
+				close(done)
+			}()
+
+			if _, err := client.Write(header); err != nil {
+				t.Fatal(err)
+			}
+			var conn net.Conn = client
+			if immediateTLS {
+				conn = tls.Client(client, &tls.Config{InsecureSkipVerify: true, ServerName: "mox.example"})
+				if err := conn.(*tls.Conn).Handshake(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			line, err := bufio.NewReader(conn).ReadString('\n')
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(line, "220 ") {
+				t.Fatalf("got greeting %q", line)
+			}
+			conn.Close()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("SMTP server did not close")
+			}
+		})
+	}
+
+	test("v1", []byte("PROXY TCP4 203.0.113.4 198.51.100.2 1234 25\r\n"), false)
+	test("v2-tls", []byte{13, 10, 13, 10, 0, 13, 10, 81, 85, 73, 84, 10, 0x21, 0x11, 0, 12, 203, 0, 113, 4, 198, 51, 100, 2, 4, 210, 1, 209}, true)
+}

--- a/smtpserver/server.go
+++ b/smtpserver/server.go
@@ -52,6 +52,7 @@ import (
 	"github.com/mjl-/mox/mlog"
 	"github.com/mjl-/mox/mox-"
 	"github.com/mjl-/mox/moxio"
+	"github.com/mjl-/mox/proxyprotocol"
 	"github.com/mjl-/mox/publicsuffix"
 	"github.com/mjl-/mox/queue"
 	"github.com/mjl-/mox/ratelimit"
@@ -236,7 +237,7 @@ func Listen() {
 					// https://github.com/golang/go/issues/70232.
 					tlsConfigDelivery.SessionTicketsDisabled = listener.SMTP.TLSSessionTicketsDisabled == nil || *listener.SMTP.TLSSessionTicketsDisabled
 				}
-				listen1("smtp", name, ip, port, hostname, tlsConfigDelivery, false, false, noTLSClientAuth, maxMsgSize, false, listener.SMTP.RequireSTARTTLS, !listener.SMTP.NoRequireTLS, listener.SMTP.DNSBLZones, firstTimeSenderDelay)
+				listen1("smtp", name, ip, port, hostname, tlsConfigDelivery, false, false, noTLSClientAuth, maxMsgSize, false, listener.SMTP.RequireSTARTTLS, !listener.SMTP.NoRequireTLS, listener.SMTP.DNSBLZones, firstTimeSenderDelay, listener.SMTP.ProxyProtocol)
 			}
 		}
 		if listener.Submission.Enabled {
@@ -246,7 +247,7 @@ func Listen() {
 			}
 			port := config.Port(listener.Submission.Port, 587)
 			for _, ip := range listener.IPs {
-				listen1("submission", name, ip, port, hostname, tlsConfig, true, false, noTLSClientAuth, maxMsgSize, !listener.Submission.NoRequireSTARTTLS, !listener.Submission.NoRequireSTARTTLS, true, nil, 0)
+				listen1("submission", name, ip, port, hostname, tlsConfig, true, false, noTLSClientAuth, maxMsgSize, !listener.Submission.NoRequireSTARTTLS, !listener.Submission.NoRequireSTARTTLS, true, nil, 0, listener.Submission.ProxyProtocol)
 			}
 		}
 
@@ -257,7 +258,7 @@ func Listen() {
 			}
 			port := config.Port(listener.Submissions.Port, 465)
 			for _, ip := range listener.IPs {
-				listen1("submissions", name, ip, port, hostname, tlsConfig, true, true, noTLSClientAuth, maxMsgSize, true, true, true, nil, 0)
+				listen1("submissions", name, ip, port, hostname, tlsConfig, true, true, noTLSClientAuth, maxMsgSize, true, true, true, nil, 0, listener.Submissions.ProxyProtocol)
 			}
 		}
 	}
@@ -265,7 +266,7 @@ func Listen() {
 
 var servers []func()
 
-func listen1(protocol, name, ip string, port int, hostname dns.Domain, tlsConfig *tls.Config, submission, xtls, noTLSClientAuth bool, maxMessageSize int64, requireTLSForAuth, requireTLSForDelivery, requireTLS bool, dnsBLs []dns.Domain, firstTimeSenderDelay time.Duration) {
+func listen1(protocol, name, ip string, port int, hostname dns.Domain, tlsConfig *tls.Config, submission, xtls, noTLSClientAuth bool, maxMessageSize int64, requireTLSForAuth, requireTLSForDelivery, requireTLS bool, dnsBLs []dns.Domain, firstTimeSenderDelay time.Duration, proxyConfig *config.ProxyProtocol) {
 	log := mlog.New("smtpserver", nil)
 	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
 	if os.Getuid() == 0 {
@@ -299,7 +300,7 @@ func listen1(protocol, name, ip string, port int, hostname dns.Domain, tlsConfig
 
 			// Package is set on the resolver by the dkim/spf/dmarc/etc packages.
 			resolver := dns.StrictResolver{Log: log.Logger}
-			go serve(name, mox.Cid(), hostname, tlsConfig, conn, resolver, submission, xtls, false, noTLSClientAuth, maxMessageSize, requireTLSForAuth, requireTLSForDelivery, requireTLS, dnsBLs, firstTimeSenderDelay)
+			go serve(name, mox.Cid(), hostname, tlsConfig, conn, resolver, submission, xtls, false, noTLSClientAuth, maxMessageSize, requireTLSForAuth, requireTLSForDelivery, requireTLS, dnsBLs, firstTimeSenderDelay, proxyConfig)
 		}
 	}
 
@@ -867,7 +868,26 @@ func ServeTLSConn(listenerName string, hostname dns.Domain, conn *tls.Conn, tlsC
 	serve(listenerName, mox.Cid(), hostname, tlsConfig, conn, resolver, submission, true, viaHTTPS, true, maxMsgSize, true, true, requireTLS, nil, 0)
 }
 
-func serve(listenerName string, cid int64, hostname dns.Domain, tlsConfig *tls.Config, nc net.Conn, resolver dns.Resolver, submission, xtls, viaHTTPS, noTLSClientAuth bool, maxMessageSize int64, requireTLSForAuth, requireTLSForDelivery, requireTLS bool, dnsBLs []dns.Domain, firstTimeSenderDelay time.Duration) {
+func serve(listenerName string, cid int64, hostname dns.Domain, tlsConfig *tls.Config, nc net.Conn, resolver dns.Resolver, submission, xtls, viaHTTPS, noTLSClientAuth bool, maxMessageSize int64, requireTLSForAuth, requireTLSForDelivery, requireTLS bool, dnsBLs []dns.Domain, firstTimeSenderDelay time.Duration, proxyConfigs ...*config.ProxyProtocol) {
+	proxyConfig := (*config.ProxyProtocol)(nil)
+	if len(proxyConfigs) > 0 {
+		proxyConfig = proxyConfigs[0]
+	}
+	rawConn := nc
+	mox.Connections.Register(rawConn, "smtp", listenerName)
+	defer mox.Connections.Unregister(rawConn)
+	if proxyConfig != nil {
+		conn, err := proxyprotocol.NewConn(rawConn, proxyConfig.TrustedProxyNets)
+		if err != nil {
+			log := mlog.New("smtpserver", nil)
+			log.Infox("smtp: proxy protocol", err, slog.String("listener", listenerName), slog.Any("remote", rawConn.RemoteAddr()))
+			if err := rawConn.Close(); err != nil {
+				log.Debugx("smtp: closing proxy protocol connection", err, slog.String("listener", listenerName))
+			}
+			return
+		}
+		nc = conn
+	}
 	var localIP, remoteIP net.IP
 	if a, ok := nc.LocalAddr().(*net.TCPAddr); ok {
 		localIP = a.IP
@@ -882,7 +902,7 @@ func serve(listenerName string, cid int64, hostname dns.Domain, tlsConfig *tls.C
 		remoteIP = net.ParseIP("127.0.0.10")
 	}
 
-	origConn := nc
+	origConn := rawConn
 	if viaHTTPS {
 		origConn = nc.(*tls.Conn).NetConn()
 	}
@@ -994,11 +1014,6 @@ func serve(listenerName string, cid int64, hostname dns.Domain, tlsConfig *tls.C
 		return
 	}
 	defer limiterConnections.Add(c.remoteIP, time.Now(), -1)
-
-	// We register and unregister the original connection, in case c.conn is replaced
-	// with a TLS connection later on.
-	mox.Connections.Register(nc, "smtp", listenerName)
-	defer mox.Connections.Unregister(nc)
 
 	// ../rfc/5321:964 ../rfc/5321:4294 about announcing software and version
 	// Syntax: ../rfc/5321:2586

--- a/vendor/github.com/pires/go-proxyproto/.gitignore
+++ b/vendor/github.com/pires/go-proxyproto/.gitignore
@@ -1,0 +1,11 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+.idea
+bin
+pkg
+
+*.out

--- a/vendor/github.com/pires/go-proxyproto/.golangci.yml
+++ b/vendor/github.com/pires/go-proxyproto/.golangci.yml
@@ -1,0 +1,35 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - canonicalheader
+    - containedctx
+    - copyloopvar
+    - goconst
+    - godot
+    - gosec
+    - modernize
+    - misspell
+    - revive
+    - unconvert
+    - usestdlibvars
+  settings:
+    goconst:
+      # Newer goconst versions default ignore-calls to false, which flags
+      # idiomatic call-argument strings such as t.Fatalf("err: %v", err) and
+      # net.Dial("tcp", addr). Restore the prior default so only genuinely
+      # repeated constant values are reported.
+      ignore-calls: true
+
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/vendor/github.com/pires/go-proxyproto/LICENSE
+++ b/vendor/github.com/pires/go-proxyproto/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Paulo Pires
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/pires/go-proxyproto/README.md
+++ b/vendor/github.com/pires/go-proxyproto/README.md
@@ -1,0 +1,165 @@
+# go-proxyproto
+
+[![Actions Status](https://github.com/pires/go-proxyproto/workflows/test/badge.svg)](https://github.com/pires/go-proxyproto/actions)
+[![Coverage Status](https://coveralls.io/repos/github/pires/go-proxyproto/badge.svg?branch=main)](https://coveralls.io/github/pires/go-proxyproto?branch=main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/pires/go-proxyproto)](https://goreportcard.com/report/github.com/pires/go-proxyproto)
+[![Go Reference](https://pkg.go.dev/badge/github.com/pires/go-proxyproto.svg)](https://pkg.go.dev/github.com/pires/go-proxyproto)
+
+
+A Go library implementation of the
+[HAProxy PROXY protocol specification 3.4](https://www.haproxy.org/download/3.4/doc/proxy-protocol.txt).
+It covers protocol versions 1 (text) and 2 (binary), carrying the original
+client connection information across NAT and proxy layers.
+
+Use it on either side of a PROXY-aware hop: send headers with `Header.WriteTo`
+or `Header.FormatUDPDatagram`, and receive them with `Listener`, `NewConn`,
+`Read`, or `ParseUDPDatagram`. The stream APIs are for TCP and Unix streams;
+UDP uses packet helpers because the spec requires a header in every datagram.
+
+## Installation
+
+```shell
+$ go get github.com/pires/go-proxyproto
+```
+
+## Examples
+
+The fastest way to get started is the runnable programs under
+[`examples/`](examples) and the API examples on
+[pkg.go.dev](https://pkg.go.dev/github.com/pires/go-proxyproto#pkg-examples):
+
+| Goal | Where to look |
+| ---- | ------------- |
+| Minimal client | [`examples/client`](examples/client) |
+| Minimal server | [`examples/server`](examples/server) |
+| HTTP server | [`examples/httpserver`](examples/httpserver) |
+| Server + client over TLS (PROXY header before TLS) | [`examples/tlsserver`](examples/tlsserver), [`examples/tlsclient`](examples/tlsclient) |
+| UDP receiver and sender | [`examples/udpserver`](examples/udpserver), [`examples/udpclient`](examples/udpclient) |
+| UDP `net.PacketConn` wrapper pattern | [`examples/udppacketconn`](examples/udppacketconn) |
+| `Listener`, `NewConn`, `Read`, UDP, and TLS API examples | [Package examples](https://pkg.go.dev/github.com/pires/go-proxyproto#pkg-examples) |
+
+## Usage
+
+Use the runnable examples above for complete programs. The core API shape is
+small.
+
+### Client side
+
+```go
+header := proxyproto.HeaderProxyFromAddrs(1, sourceAddr, destinationAddr)
+_, err := header.WriteTo(conn) // write the PROXY header before application data
+```
+
+See [`examples/client`](examples/client) for a complete TCP client.
+
+### Server side
+
+```go
+proxyListener := &proxyproto.Listener{Listener: ln}
+conn, err := proxyListener.Accept()
+// Connections must open with a PROXY header (the default policy is REQUIRE);
+// conn.RemoteAddr() then reports the client address from that header.
+```
+
+See [`examples/server`](examples/server) for a complete TCP server. For HTTP/1
+and HTTP/2, see [`examples/httpserver`](examples/httpserver), which uses
+[`helper/http2`](helper/http2) so one server can accept proxied HTTP/1 and HTTP/2
+connections.
+
+> [!WARNING]
+> The zero-value configuration requires the PROXY header but still honors it
+> from any peer. It is not safe for listeners reachable by untrusted clients
+> without a trusted-source policy. See [Security](#security).
+
+## Security
+
+The PROXY header replaces what your application sees as the client address, so
+whoever is allowed to send one can spoof their origin. The spec (section 2)
+says receivers "MUST not try to guess" whether the header is present, and
+requires access filtering so only trusted proxies can use the protocol.
+
+Important stream defaults and policies:
+
+- With no policy configured, `Listener` and `NewConn` use
+  `proxyproto.DefaultPolicy`, which is `REQUIRE`. A connection that does not
+  open with a PROXY header fails its first I/O with `ErrNoProxyProtocol`, so
+  header presence is never guessed.
+- `REQUIRE` still honors headers from any peer. Use it only when the listener
+  is reachable exclusively by trusted proxies, such as a private network
+  segment behind your load balancer.
+- Deployments that need historical optional-header behavior can restore it
+  process-wide with `proxyproto.DefaultPolicy = proxyproto.USE`, per
+  connection with `WithPolicy(USE)`, or per listener with a policy returning
+  `USE`.
+- For exposed listeners, restrict the senders with `TrustProxyHeaderFrom` or
+  `TrustProxyHeaderFromRanges`. Trusted peers must send a header; untrusted
+  peers are dropped by `Accept`. For example:
+
+```go
+proxyListener := &proxyproto.Listener{
+	Listener: ln,
+	// Connections from the load balancer must open with a PROXY header
+	// (REQUIRE); connections from any other source are dropped. For CIDR
+	// ranges, use TrustProxyHeaderFromRanges([]string{"10.0.0.0/24"}).
+	// For mixed traffic (e.g. optional headers from some sources), spell the
+	// two policies out with PolicyFromRanges(ranges, matched, unmatched).
+	ConnPolicy: proxyproto.TrustProxyHeaderFrom(net.ParseIP("10.0.0.10")),
+}
+```
+
+For UDP, `ParseUDPDatagram` has no built-in trusted-source policy because it
+only sees packet bytes. Check the `net.PacketConn.ReadFrom` sender address
+yourself before trusting `header.SourceAddr`.
+
+Related knobs are documented in the
+[package docs](https://pkg.go.dev/github.com/pires/go-proxyproto):
+`ReadHeaderTimeout` (default 10s), `MaxV2HeaderSize` (default 4KiB),
+`V1AcceptIPv4InTCP6` (default off), and `Listener.ValidateHeader`.
+
+## UDP
+
+The spec requires the header and proxied payload in the same UDP datagram, and
+the receiver must parse the header independently for every datagram. `Listener`
+and `Conn` cannot provide those semantics; use `ParseUDPDatagram` and
+`Header.FormatUDPDatagram` with your own `net.PacketConn`. Headers with
+`UDPv4`/`UDPv6` families carried over stream connections describe the proxied
+protocol and remain fully supported.
+
+- [`examples/udpserver`](examples/udpserver) and
+  [`examples/udpclient`](examples/udpclient) show direct per-datagram parsing
+  and formatting.
+- [`examples/udppacketconn`](examples/udppacketconn) sketches a
+  `net.PacketConn` wrapper with reply routing through the relaying proxy.
+- [`ExampleParseUDPDatagram`](https://pkg.go.dev/github.com/pires/go-proxyproto#example-ParseUDPDatagram)
+  and
+  [`ExampleHeader_FormatUDPDatagram`](https://pkg.go.dev/github.com/pires/go-proxyproto#example-Header.FormatUDPDatagram)
+  show the same APIs as package examples.
+
+The library deliberately does not export a `net.PacketConn` wrapper. A wrapper
+that returns the client address from the header also needs an application-owned
+client-to-proxy flow table for replies, including bounds, expiry, and spoofing
+policy.
+
+### TLS
+
+When combining PROXY protocol with TLS, match the wrapper order to the upstream
+order. If the header is sent in cleartext before the handshake, put proxyproto
+inside TLS: `tls.NewListener(&proxyproto.Listener{Listener: l}, tlsConfig)`.
+If the header is sent inside the TLS session, decrypt first:
+`&proxyproto.Listener{Listener: tls.NewListener(l, tlsConfig)}`. In both cases
+`conn.RemoteAddr()` reports the client carried by the PROXY header.
+
+Runnable code lives in [`examples/tlsserver`](examples/tlsserver) and
+[`examples/tlsclient`](examples/tlsclient). Package examples show both
+orderings.
+
+## Special notes
+
+### AWS
+
+AWS Network Load Balancer (NLB) does not send the PROXY v2 header until the
+client sends payload: the target group attribute
+`proxy_protocol_v2.client_to_server.header_placement` defaults to
+`on_first_ack_with_payload`. Server-first protocols such as SMTP, FTP, and SSH
+fail in that mode; contact AWS support to change the attribute to
+`on_first_ack` so the header arrives before the backend speaks.

--- a/vendor/github.com/pires/go-proxyproto/addr_proto.go
+++ b/vendor/github.com/pires/go-proxyproto/addr_proto.go
@@ -1,0 +1,80 @@
+package proxyproto
+
+// AddressFamilyAndProtocol represents address family and transport protocol.
+type AddressFamilyAndProtocol byte
+
+// AddressFamilyAndProtocol enum values.
+const (
+	UNSPEC       AddressFamilyAndProtocol = '\x00'
+	TCPv4        AddressFamilyAndProtocol = '\x11'
+	UDPv4        AddressFamilyAndProtocol = '\x12'
+	TCPv6        AddressFamilyAndProtocol = '\x21'
+	UDPv6        AddressFamilyAndProtocol = '\x22'
+	UnixStream   AddressFamilyAndProtocol = '\x31'
+	UnixDatagram AddressFamilyAndProtocol = '\x32'
+)
+
+// supportedTransportProtocol is the set of address-family/transport-protocol
+// bytes defined by the PROXY protocol v2 spec (section 2.2). Any other value is
+// rejected during v2 parsing. This matters for bytes that share a known family
+// but an undefined transport (e.g. 0x13: IPv4 family, transport 3): they pass
+// the IsIPv4/IsIPv6 family checks yet are neither stream nor datagram, so
+// newIPAddr would return a nil net.Addr and later panic callers of
+// RemoteAddr().String() / LocalAddr().String().
+var supportedTransportProtocol = map[AddressFamilyAndProtocol]bool{
+	UNSPEC:       true,
+	TCPv4:        true,
+	UDPv4:        true,
+	TCPv6:        true,
+	UDPv6:        true,
+	UnixStream:   true,
+	UnixDatagram: true,
+}
+
+// IsIPv4 returns true if the address family is IPv4 (AF_INET4), false otherwise.
+func (ap AddressFamilyAndProtocol) IsIPv4() bool {
+	return ap&0xF0 == 0x10
+}
+
+// IsIPv6 returns true if the address family is IPv6 (AF_INET6), false otherwise.
+func (ap AddressFamilyAndProtocol) IsIPv6() bool {
+	return ap&0xF0 == 0x20
+}
+
+// IsUnix returns true if the address family is UNIX (AF_UNIX), false otherwise.
+func (ap AddressFamilyAndProtocol) IsUnix() bool {
+	return ap&0xF0 == 0x30
+}
+
+// IsStream returns true if the transport protocol is TCP or STREAM (SOCK_STREAM), false otherwise.
+func (ap AddressFamilyAndProtocol) IsStream() bool {
+	return ap&0x0F == 0x01
+}
+
+// IsDatagram returns true if the transport protocol is UDP or DGRAM (SOCK_DGRAM), false otherwise.
+func (ap AddressFamilyAndProtocol) IsDatagram() bool {
+	return ap&0x0F == 0x02
+}
+
+// IsUnspec returns true if the transport protocol or address family is unspecified, false otherwise.
+func (ap AddressFamilyAndProtocol) IsUnspec() bool {
+	return (ap&0xF0 == 0x00) || (ap&0x0F == 0x00)
+}
+
+func (ap AddressFamilyAndProtocol) toByte() byte {
+	if ap.IsIPv4() && ap.IsStream() {
+		return byte(TCPv4)
+	} else if ap.IsIPv4() && ap.IsDatagram() {
+		return byte(UDPv4)
+	} else if ap.IsIPv6() && ap.IsStream() {
+		return byte(TCPv6)
+	} else if ap.IsIPv6() && ap.IsDatagram() {
+		return byte(UDPv6)
+	} else if ap.IsUnix() && ap.IsStream() {
+		return byte(UnixStream)
+	} else if ap.IsUnix() && ap.IsDatagram() {
+		return byte(UnixDatagram)
+	}
+
+	return byte(UNSPEC)
+}

--- a/vendor/github.com/pires/go-proxyproto/header.go
+++ b/vendor/github.com/pires/go-proxyproto/header.go
@@ -1,0 +1,382 @@
+// Package proxyproto implements Proxy Protocol (v1 and v2) parser and writer, as per specification:
+// https://www.haproxy.org/download/3.4/doc/proxy-protocol.txt
+package proxyproto
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"time"
+)
+
+// Network names for Unix-domain addresses, matching net.UnixAddr.Net values.
+// The net package exposes no constants for these.
+const (
+	networkUnix     = "unix"
+	networkUnixgram = "unixgram"
+)
+
+var (
+	// SIGV1 is the signature for PROXY protocol v1.
+	SIGV1 = []byte{'\x50', '\x52', '\x4F', '\x58', '\x59'}
+	// SIGV2 is the signature for PROXY protocol v2.
+	SIGV2 = []byte{'\x0D', '\x0A', '\x0D', '\x0A', '\x00', '\x0D', '\x0A', '\x51', '\x55', '\x49', '\x54', '\x0A'}
+
+	// ErrCantReadVersion1Header indicates a v1 header could not be read.
+	ErrCantReadVersion1Header = errors.New("proxyproto: can't read version 1 header")
+	// ErrVersion1HeaderTooLong indicates a v1 header is too long.
+	ErrVersion1HeaderTooLong = errors.New("proxyproto: version 1 header must be 107 bytes or less")
+	// ErrLineMustEndWithCrlf indicates a v1 header is invalid, must end with \r\n.
+	ErrLineMustEndWithCrlf = errors.New("proxyproto: version 1 header is invalid, must end with \\r\\n")
+	// ErrCantReadProtocolVersionAndCommand indicates a protocol version and command could not be read.
+	ErrCantReadProtocolVersionAndCommand = errors.New("proxyproto: can't read proxy protocol version and command")
+	// ErrCantReadAddressFamilyAndProtocol indicates an address family and protocol could not be read.
+	ErrCantReadAddressFamilyAndProtocol = errors.New("proxyproto: can't read address family or protocol")
+	// ErrCantReadLength indicates a length could not be read.
+	ErrCantReadLength = errors.New("proxyproto: can't read length")
+	// ErrCantResolveSourceUnixAddress indicates a source Unix address could not be resolved.
+	ErrCantResolveSourceUnixAddress = errors.New("proxyproto: can't resolve source Unix address")
+	// ErrCantResolveDestinationUnixAddress indicates a destination Unix address could not be resolved.
+	ErrCantResolveDestinationUnixAddress = errors.New("proxyproto: can't resolve destination Unix address")
+	// ErrNoProxyProtocol indicates a proxy protocol signature is not present.
+	ErrNoProxyProtocol = errors.New("proxyproto: proxy protocol signature not present")
+	// ErrUnknownProxyProtocolVersion indicates an unknown proxy protocol version.
+	ErrUnknownProxyProtocolVersion = errors.New("proxyproto: unknown proxy protocol version")
+	// ErrUnsupportedProtocolVersionAndCommand indicates an unsupported protocol version and command.
+	ErrUnsupportedProtocolVersionAndCommand = errors.New("proxyproto: unsupported proxy protocol version and command")
+	// ErrUnsupportedAddressFamilyAndProtocol indicates an unsupported address family and protocol.
+	ErrUnsupportedAddressFamilyAndProtocol = errors.New("proxyproto: unsupported address family and protocol")
+	// ErrInvalidLength indicates an invalid length.
+	ErrInvalidLength = errors.New("proxyproto: invalid length")
+	// ErrInvalidAddress indicates an invalid address.
+	ErrInvalidAddress = errors.New("proxyproto: invalid address")
+	// ErrInvalidPortNumber indicates an invalid port number.
+	ErrInvalidPortNumber = errors.New("proxyproto: invalid port number")
+	// ErrSuperfluousProxyHeader indicates an upstream connection sent a PROXY header but isn't allowed to send one.
+	ErrSuperfluousProxyHeader = errors.New("proxyproto: upstream connection sent PROXY header but isn't allowed to send one")
+)
+
+// Header is the placeholder for proxy protocol header.
+type Header struct {
+	Version           byte
+	Command           ProtocolVersionAndCommand
+	TransportProtocol AddressFamilyAndProtocol
+	SourceAddr        net.Addr
+	DestinationAddr   net.Addr
+	rawTLVs           []byte
+}
+
+// HeaderProxyFromAddrs creates a new PROXY header from a source and a
+// destination address. If version is zero, the latest protocol version is
+// used.
+//
+// The header is filled on a best-effort basis: if hints cannot be inferred
+// from the provided addresses, the header will be left unspecified.
+func HeaderProxyFromAddrs(version byte, sourceAddr, destAddr net.Addr) *Header {
+	if version < 1 || version > 2 {
+		version = 2
+	}
+	h := &Header{
+		Version:           version,
+		Command:           LOCAL,
+		TransportProtocol: UNSPEC,
+	}
+	switch sourceAddr := sourceAddr.(type) {
+	case *net.TCPAddr:
+		// Both ends must be the same Addr type; bind destAddr to read its IP below.
+		destAddr, ok := destAddr.(*net.TCPAddr)
+		if !ok {
+			break
+		}
+		// Pick the family from BOTH addresses, not just the source: use v4 only
+		// when both are IPv4, otherwise fall back to v6 (the v4 side is then
+		// serialized as a v4-mapped IPv6, ::ffff:x.x.x.x). The previous
+		// source-only check mislabeled a v4-source/v6-dest pair as TCPv4 and then
+		// failed in formatVersion1.
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
+			h.TransportProtocol = TCPv4
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
+			h.TransportProtocol = TCPv6
+		}
+	case *net.UDPAddr:
+		destAddr, ok := destAddr.(*net.UDPAddr)
+		if !ok {
+			break
+		}
+		// Same both-ends family selection as TCP above.
+		switch {
+		case sourceAddr.IP.To4() != nil && destAddr.IP.To4() != nil:
+			h.TransportProtocol = UDPv4
+		case sourceAddr.IP.To16() != nil && destAddr.IP.To16() != nil:
+			h.TransportProtocol = UDPv6
+		}
+	case *net.UnixAddr:
+		destAddr, ok := destAddr.(*net.UnixAddr)
+		if !ok {
+			break
+		}
+		// Both ends must agree on stream vs datagram: there is no meaningful
+		// connection mixing the two, so a mismatched pair stays UNSPEC rather than
+		// being labeled with the source's flavor alone. Mirrors the both-ends
+		// family selection used for TCP/UDP above.
+		if sourceAddr.Net != destAddr.Net {
+			break
+		}
+		switch sourceAddr.Net {
+		case networkUnix:
+			h.TransportProtocol = UnixStream
+		case networkUnixgram:
+			h.TransportProtocol = UnixDatagram
+		}
+	}
+	if h.TransportProtocol != UNSPEC {
+		h.Command = PROXY
+		h.SourceAddr = sourceAddr
+		h.DestinationAddr = destAddr
+	}
+	return h
+}
+
+// TCPAddrs returns TCP source/destination addresses if the header is stream-based.
+func (header *Header) TCPAddrs() (sourceAddr, destAddr *net.TCPAddr, ok bool) {
+	if !header.TransportProtocol.IsStream() {
+		return nil, nil, false
+	}
+	sourceAddr, sourceOK := header.SourceAddr.(*net.TCPAddr)
+	destAddr, destOK := header.DestinationAddr.(*net.TCPAddr)
+	return sourceAddr, destAddr, sourceOK && destOK
+}
+
+// UDPAddrs returns UDP source/destination addresses if the header is datagram-based.
+func (header *Header) UDPAddrs() (sourceAddr, destAddr *net.UDPAddr, ok bool) {
+	if !header.TransportProtocol.IsDatagram() {
+		return nil, nil, false
+	}
+	sourceAddr, sourceOK := header.SourceAddr.(*net.UDPAddr)
+	destAddr, destOK := header.DestinationAddr.(*net.UDPAddr)
+	return sourceAddr, destAddr, sourceOK && destOK
+}
+
+// UnixAddrs returns UNIX source/destination addresses if the header is UNIX-based.
+func (header *Header) UnixAddrs() (sourceAddr, destAddr *net.UnixAddr, ok bool) {
+	if !header.TransportProtocol.IsUnix() {
+		return nil, nil, false
+	}
+	sourceAddr, sourceOK := header.SourceAddr.(*net.UnixAddr)
+	destAddr, destOK := header.DestinationAddr.(*net.UnixAddr)
+	return sourceAddr, destAddr, sourceOK && destOK
+}
+
+// IPs returns source/destination IPs for TCP/UDP headers.
+func (header *Header) IPs() (sourceIP, destIP net.IP, ok bool) {
+	if sourceAddr, destAddr, ok := header.TCPAddrs(); ok {
+		return sourceAddr.IP, destAddr.IP, true
+	}
+	if sourceAddr, destAddr, ok := header.UDPAddrs(); ok {
+		return sourceAddr.IP, destAddr.IP, true
+	}
+	return nil, nil, false
+}
+
+// Ports returns source/destination ports for TCP/UDP headers.
+func (header *Header) Ports() (sourcePort, destPort int, ok bool) {
+	if sourceAddr, destAddr, ok := header.TCPAddrs(); ok {
+		return sourceAddr.Port, destAddr.Port, true
+	}
+	if sourceAddr, destAddr, ok := header.UDPAddrs(); ok {
+		return sourceAddr.Port, destAddr.Port, true
+	}
+	return 0, 0, false
+}
+
+// EqualTo returns true if headers are equivalent, false otherwise.
+// Deprecated: use EqualsTo instead. This method will eventually be removed.
+func (header *Header) EqualTo(otherHeader *Header) bool {
+	return header.EqualsTo(otherHeader)
+}
+
+// EqualsTo returns true if headers are equivalent, false otherwise.
+func (header *Header) EqualsTo(otherHeader *Header) bool {
+	if otherHeader == nil {
+		return false
+	}
+	if header.Version != otherHeader.Version || header.Command != otherHeader.Command || header.TransportProtocol != otherHeader.TransportProtocol {
+		return false
+	}
+	// TLVs only exist for version 2
+	if header.Version == 2 && !bytes.Equal(header.rawTLVs, otherHeader.rawTLVs) {
+		return false
+	}
+	// Return early for header with LOCAL command, which contains no address information
+	if header.Command == LOCAL {
+		return true
+	}
+	return addrsEqual(header.SourceAddr, otherHeader.SourceAddr) &&
+		addrsEqual(header.DestinationAddr, otherHeader.DestinationAddr)
+}
+
+// addrsEqual compares two net.Addr by their rendered form, without panicking
+// when either side is nil (hand-built PROXY headers may lack addresses).
+func addrsEqual(a, b net.Addr) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.String() == b.String()
+}
+
+// WriteTo renders a proxy protocol header in a format and writes it to an io.Writer.
+func (header *Header) WriteTo(w io.Writer) (int64, error) {
+	buf, err := header.Format()
+	if err != nil {
+		return 0, err
+	}
+
+	return bytes.NewReader(buf).WriteTo(w)
+}
+
+// Format renders a proxy protocol header in a format to write over the wire.
+func (header *Header) Format() ([]byte, error) {
+	switch header.Version {
+	case 1:
+		return header.formatVersion1()
+	case 2:
+		return header.formatVersion2()
+	default:
+		return nil, ErrUnknownProxyProtocolVersion
+	}
+}
+
+// TLVs returns the TLVs stored into this header, if they exist.  TLVs are optional for v2 of the protocol.
+func (header *Header) TLVs() ([]TLV, error) {
+	return SplitTLVs(header.rawTLVs)
+}
+
+// SetTLVs sets the TLVs stored in this header. This method replaces any
+// previous TLV.
+func (header *Header) SetTLVs(tlvs []TLV) error {
+	raw, err := JoinTLVs(tlvs)
+	if err != nil {
+		return err
+	}
+	header.rawTLVs = raw
+	return nil
+}
+
+// Read identifies the proxy protocol version and reads the remaining of
+// the header, accordingly.
+//
+// If proxy protocol header signature is not present, the reader buffer remains untouched
+// and is safe for reading outside of this code.
+//
+// If proxy protocol header signature is present but an error is raised while processing
+// the remaining header, assume the reader buffer to be in a corrupt state.
+// Also, this operation will block until enough bytes are available for peeking.
+func Read(reader *bufio.Reader) (*Header, error) {
+	// In order to improve speed for small non-PROXYed packets, take a peek at the first byte alone.
+	b1, err := reader.Peek(1)
+	if err != nil {
+		if err == io.EOF {
+			return nil, ErrNoProxyProtocol
+		}
+		return nil, err
+	}
+
+	if bytes.Equal(b1[:1], SIGV1[:1]) || bytes.Equal(b1[:1], SIGV2[:1]) {
+		signature, err := reader.Peek(5)
+		if err != nil {
+			if err == io.EOF {
+				return nil, ErrNoProxyProtocol
+			}
+			return nil, err
+		}
+		if bytes.Equal(signature[:5], SIGV1) {
+			return parseVersion1(reader)
+		}
+
+		signature, err = reader.Peek(12)
+		if err != nil {
+			if err == io.EOF {
+				return nil, ErrNoProxyProtocol
+			}
+			return nil, err
+		}
+		if bytes.Equal(signature[:12], SIGV2) {
+			return parseVersion2(reader)
+		}
+	}
+
+	return nil, ErrNoProxyProtocol
+}
+
+// ReadTimeout acts as Read but takes a timeout. If that timeout is reached, it's assumed
+// there's no proxy protocol header.
+//
+// Deprecated: ReadTimeout cannot cancel the read it starts. It only receives a
+// *bufio.Reader, so on timeout it has no way to set a deadline on or close the
+// underlying connection: the goroutine it spawns stays blocked in Read, peeking
+// at the stalled connection, until the peer sends data or the connection is
+// closed elsewhere. Each timed-out call therefore leaks that goroutine and the
+// connection's file descriptor. Use ReadHeaderTimeout instead, which also takes
+// the net.Conn and sets a real read deadline so the read is actually cancelled
+// on timeout; or wrap the connection with NewConn or a Listener and configure
+// the header timeout via the SetReadHeaderTimeout option or
+// Listener.ReadHeaderTimeout.
+func ReadTimeout(reader *bufio.Reader, timeout time.Duration) (*Header, error) {
+	type header struct {
+		h *Header
+		e error
+	}
+	read := make(chan *header, 1)
+
+	go func() {
+		h := &header{}
+		h.h, h.e = Read(reader)
+		read <- h
+	}()
+
+	timer := time.NewTimer(timeout)
+	select {
+	case result := <-read:
+		timer.Stop()
+		return result.h, result.e
+	case <-timer.C:
+		return nil, ErrNoProxyProtocol
+	}
+}
+
+// ReadHeaderTimeout reads the PROXY protocol header from conn, giving up after
+// timeout. It is the cancellable replacement for the deprecated ReadTimeout:
+// because it is given the net.Conn, it sets a read deadline so a stalled read is
+// actually interrupted instead of leaking a blocked goroutine and the
+// connection's file descriptor. If the timeout is reached it returns
+// ErrNoProxyProtocol, assuming no header is present.
+//
+// reader must be buffered over conn (for example bufio.NewReader(conn)); it is
+// used for the header read so that any bytes buffered past the header remain
+// available for the caller to read afterwards. A timeout <= 0 reads without a
+// deadline.
+//
+// ReadHeaderTimeout overwrites conn's read deadline and restores the zero (no)
+// deadline before returning; re-apply your own read deadline afterwards if you
+// had one set.
+func ReadHeaderTimeout(conn net.Conn, reader *bufio.Reader, timeout time.Duration) (*Header, error) {
+	if timeout > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+			return nil, err
+		}
+		// Best-effort restore of the zero deadline. A failure here (e.g. the
+		// peer has already closed) must not mask a header we parsed, so the
+		// error is intentionally ignored; the header/err from Read is
+		// authoritative.
+		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	}
+
+	header, err := Read(reader)
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return nil, ErrNoProxyProtocol
+	}
+	return header, err
+}

--- a/vendor/github.com/pires/go-proxyproto/policy.go
+++ b/vendor/github.com/pires/go-proxyproto/policy.go
@@ -1,0 +1,438 @@
+package proxyproto
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// PolicyFunc can be used to decide whether to trust the PROXY info from
+// upstream. If set, the connecting address is passed in as an argument.
+//
+// See below for the different policies.
+//
+// In case an error is returned the connection is denied: an error wrapping
+// ErrInvalidUpstream denies just that connection while Listener.Accept keeps
+// listening; any other error is returned by Accept itself, which typically
+// stops the caller's accept loop.
+//
+// Deprecated: use ConnPolicyFunc instead.
+type PolicyFunc func(upstream net.Addr) (Policy, error)
+
+// ConnPolicyFunc can be used to decide whether to trust the PROXY info
+// based on connection policy options. If set, the connecting addresses
+// (remote and local) are passed in as argument.
+//
+// See below for the different policies.
+//
+// In case an error is returned the connection is denied: an error wrapping
+// ErrInvalidUpstream denies just that connection while Listener.Accept keeps
+// listening; any other error is returned by Accept itself, which typically
+// stops the caller's accept loop.
+type ConnPolicyFunc func(connPolicyOptions ConnPolicyOptions) (Policy, error)
+
+// ConnPolicyOptions contains the remote and local addresses of a connection.
+type ConnPolicyOptions struct {
+	Upstream   net.Addr
+	Downstream net.Addr
+}
+
+// Policy defines how a connection with a PROXY header address is treated.
+type Policy int
+
+const (
+	// USE address from PROXY header.
+	USE Policy = iota
+	// IGNORE address from PROXY header, but accept connection.
+	IGNORE
+	// REJECT connection when PROXY header is sent
+	// Note: if a PROXY header is present the first read returns
+	// ErrSuperfluousProxyHeader, and every subsequent read returns the same
+	// error, so the connection should be closed.
+	REJECT
+	// REQUIRE connection to send PROXY header, reject if not present
+	// Note: if no PROXY header is present the first read returns
+	// ErrNoProxyProtocol, and every subsequent read returns the same error,
+	// so the connection should be closed.
+	REQUIRE
+	// SKIP accepts a connection without requiring the PROXY header.
+	// Note: an example usage can be found in the SkipProxyHeaderForCIDR
+	// function.
+	//
+	// On a Listener, SKIP short-circuits Accept and returns the raw, unwrapped
+	// connection. On a Conn (via WithPolicy), a PROXY header that is present is
+	// still consumed from the stream but discarded: ProxyHeader returns nil and
+	// no validation runs.
+	SKIP
+)
+
+// DefaultPolicy is the policy applied when none is configured explicitly: by
+// NewConn when no WithPolicy option is given, and by Listener.Accept when
+// neither Policy nor ConnPolicy is set.
+//
+// It defaults to REQUIRE, per the spec's mandate that a receiver "MUST not try
+// to guess whether the protocol header is present or not": a connection that
+// does not open with a PROXY header fails its first Read/Write with
+// ErrNoProxyProtocol. Note REQUIRE alone still honors headers from any peer;
+// restricting who may send one needs a policy such as TrustProxyHeaderFrom or
+// TrustProxyHeaderFromRanges. (The deprecated *WhiteListPolicy helpers are
+// NOT equivalent: they return USE for allowed peers, which replaces this
+// default and makes the header optional again — that is why they were
+// deprecated in favor of the explicit PolicyFromRanges.)
+//
+// Deployments that relied on the historical optional-header behavior can
+// restore it process-wide with:
+//
+//	proxyproto.DefaultPolicy = proxyproto.USE
+//
+// Like DefaultReadHeaderTimeout, this is a package-level variable to keep it
+// easy to override. Set it at program init; it must not be modified
+// concurrently with accepting connections.
+var DefaultPolicy = REQUIRE
+
+// ConnSkipProxyHeaderForCIDR returns a ConnPolicyFunc which can be used to accept
+// a connection from a skipHeaderCIDR without requiring a PROXY header, e.g.
+// Kubernetes pods local traffic. The def is a policy to use when an upstream
+// address doesn't match the skipHeaderCIDR.
+func ConnSkipProxyHeaderForCIDR(skipHeaderCIDR *net.IPNet, def Policy) ConnPolicyFunc {
+	return func(connOpts ConnPolicyOptions) (Policy, error) {
+		ip, err := ipFromAddr(connOpts.Upstream)
+		if err != nil {
+			// Deny only this connection: wrapping ErrInvalidUpstream keeps
+			// Listener.Accept listening instead of surfacing the error and
+			// stopping the caller's accept loop.
+			return def, fmt.Errorf("%w: %w", ErrInvalidUpstream, err)
+		}
+
+		if skipHeaderCIDR != nil && skipHeaderCIDR.Contains(ip) {
+			return SKIP, nil
+		}
+
+		return def, nil
+	}
+}
+
+// SkipProxyHeaderForCIDR returns a PolicyFunc which can be used to accept a
+// connection from a skipHeaderCIDR without requiring a PROXY header, e.g.
+// Kubernetes pods local traffic. The def is a policy to use when an upstream
+// address doesn't match the skipHeaderCIDR.
+//
+// Deprecated: use ConnSkipProxyHeaderForCIDR instead.
+func SkipProxyHeaderForCIDR(skipHeaderCIDR *net.IPNet, def Policy) PolicyFunc {
+	connPolicy := ConnSkipProxyHeaderForCIDR(skipHeaderCIDR, def)
+	return func(upstream net.Addr) (Policy, error) {
+		return connPolicy(ConnPolicyOptions{Upstream: upstream})
+	}
+}
+
+// WithPolicy adds given policy to a connection when passed as option to NewConn().
+func WithPolicy(p Policy) func(*Conn) {
+	return func(c *Conn) {
+		c.ProxyHeaderPolicy = p
+	}
+}
+
+// ConnLaxWhiteListPolicy returns a ConnPolicyFunc which decides whether the
+// upstream ip is allowed to send a proxy header based on a list of allowed
+// IP addresses and IP ranges. In case upstream IP is not in list the proxy
+// header will be ignored. If one of the provided IP addresses or IP ranges
+// is invalid it will return an error instead of a ConnPolicyFunc.
+//
+// Deprecated: the name hides that the header stays optional (USE) for allowed
+// peers, overriding the REQUIRE default. Use the equivalent, explicit
+// PolicyFromRanges(allowed, USE, IGNORE), or TrustProxyHeaderFromRanges for
+// the spec-strict header-mandatory posture.
+func ConnLaxWhiteListPolicy(allowed []string) (ConnPolicyFunc, error) {
+	return PolicyFromRanges(allowed, USE, IGNORE)
+}
+
+// LaxWhiteListPolicy returns a PolicyFunc which decides whether the
+// upstream ip is allowed to send a proxy header based on a list of allowed
+// IP addresses and IP ranges. In case upstream IP is not in list the proxy
+// header will be ignored. If one of the provided IP addresses or IP ranges
+// is invalid it will return an error instead of a PolicyFunc.
+//
+// Deprecated: use PolicyFromRanges(allowed, USE, IGNORE) instead; see
+// ConnLaxWhiteListPolicy for why.
+func LaxWhiteListPolicy(allowed []string) (PolicyFunc, error) {
+	connPolicy, err := ConnLaxWhiteListPolicy(allowed)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(upstream net.Addr) (Policy, error) {
+		return connPolicy(ConnPolicyOptions{Upstream: upstream})
+	}, nil
+}
+
+// ConnMustLaxWhiteListPolicy returns a ConnLaxWhiteListPolicy but will panic
+// if one of the provided IP addresses or IP ranges is invalid.
+//
+// Deprecated: use MustPolicyFromRanges(allowed, USE, IGNORE) instead; see
+// ConnLaxWhiteListPolicy for why.
+func ConnMustLaxWhiteListPolicy(allowed []string) ConnPolicyFunc {
+	pfunc, err := ConnLaxWhiteListPolicy(allowed)
+	if err != nil {
+		panic(err)
+	}
+
+	return pfunc
+}
+
+// MustLaxWhiteListPolicy returns a LaxWhiteListPolicy but will panic if one
+// of the provided IP addresses or IP ranges is invalid.
+//
+// Deprecated: use MustPolicyFromRanges(allowed, USE, IGNORE) instead; see
+// ConnLaxWhiteListPolicy for why.
+func MustLaxWhiteListPolicy(allowed []string) PolicyFunc {
+	connPolicy := ConnMustLaxWhiteListPolicy(allowed)
+	return func(upstream net.Addr) (Policy, error) {
+		return connPolicy(ConnPolicyOptions{Upstream: upstream})
+	}
+}
+
+// ConnStrictWhiteListPolicy returns a ConnPolicyFunc which decides whether the
+// upstream ip is allowed to send a proxy header based on a list of allowed
+// IP addresses and IP ranges. In case upstream IP is not in list reading on
+// the connection will be refused: the first read returns
+// ErrSuperfluousProxyHeader and every subsequent read returns the same error,
+// so the connection should be closed. If one of the provided IP addresses or IP
+// ranges is invalid it will return an error instead of a ConnPolicyFunc.
+//
+// Deprecated: "strict" only refers to refusing headers from unlisted peers;
+// the header stays optional (USE) for allowed peers, overriding the REQUIRE
+// default. Use the equivalent, explicit PolicyFromRanges(allowed, USE,
+// REJECT), or TrustProxyHeaderFromRanges for the spec-strict header-mandatory
+// posture.
+func ConnStrictWhiteListPolicy(allowed []string) (ConnPolicyFunc, error) {
+	return PolicyFromRanges(allowed, USE, REJECT)
+}
+
+// StrictWhiteListPolicy returns a PolicyFunc which decides whether the
+// upstream ip is allowed to send a proxy header based on a list of allowed
+// IP addresses and IP ranges. In case upstream IP is not in list reading on
+// the connection will be refused: the first read returns
+// ErrSuperfluousProxyHeader and every subsequent read returns the same error,
+// so the connection should be closed. If one of the provided IP addresses or IP
+// ranges is invalid it will return an error instead of a PolicyFunc.
+//
+// Deprecated: use PolicyFromRanges(allowed, USE, REJECT) instead; see
+// ConnStrictWhiteListPolicy for why.
+func StrictWhiteListPolicy(allowed []string) (PolicyFunc, error) {
+	connPolicy, err := ConnStrictWhiteListPolicy(allowed)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(upstream net.Addr) (Policy, error) {
+		return connPolicy(ConnPolicyOptions{Upstream: upstream})
+	}, nil
+}
+
+// ConnMustStrictWhiteListPolicy returns a ConnStrictWhiteListPolicy but will panic
+// if one of the provided IP addresses or IP ranges is invalid.
+//
+// Deprecated: use MustPolicyFromRanges(allowed, USE, REJECT) instead; see
+// ConnStrictWhiteListPolicy for why.
+func ConnMustStrictWhiteListPolicy(allowed []string) ConnPolicyFunc {
+	pfunc, err := ConnStrictWhiteListPolicy(allowed)
+	if err != nil {
+		panic(err)
+	}
+
+	return pfunc
+}
+
+// MustStrictWhiteListPolicy returns a StrictWhiteListPolicy but will panic
+// if one of the provided IP addresses or IP ranges is invalid.
+//
+// Deprecated: use MustPolicyFromRanges(allowed, USE, REJECT) instead; see
+// ConnStrictWhiteListPolicy for why.
+func MustStrictWhiteListPolicy(allowed []string) PolicyFunc {
+	connPolicy := ConnMustStrictWhiteListPolicy(allowed)
+	return func(upstream net.Addr) (Policy, error) {
+		return connPolicy(ConnPolicyOptions{Upstream: upstream})
+	}
+}
+
+func connRangesPolicy(allowed []func(net.IP) bool, matched, unmatched Policy) ConnPolicyFunc {
+	return func(connOpts ConnPolicyOptions) (Policy, error) {
+		upstreamIP, err := ipFromAddr(connOpts.Upstream)
+		if err != nil {
+			// Something is wrong with the source IP: deny only this connection.
+			// Wrapping ErrInvalidUpstream keeps Listener.Accept listening instead
+			// of surfacing the error and stopping the caller's accept loop.
+			return REJECT, fmt.Errorf("%w: %w", ErrInvalidUpstream, err)
+		}
+
+		for _, allowFrom := range allowed {
+			if allowFrom(upstreamIP) {
+				return matched, nil
+			}
+		}
+
+		return unmatched, nil
+	}
+}
+
+// PolicyFromRanges returns a ConnPolicyFunc that applies the matched policy to
+// connections whose upstream address belongs to ranges, and the unmatched
+// policy to every other connection. Each entry in ranges may be an individual
+// IP address ("10.0.0.10") or a CIDR range ("10.0.0.0/24"); an invalid entry
+// returns an error instead of a ConnPolicyFunc. Connections whose upstream
+// address cannot be classified are dropped by Listener.Accept via an
+// ErrInvalidUpstream-wrapping error.
+//
+// It is the explicit replacement for the deprecated *WhiteListPolicy helpers:
+//
+//	PolicyFromRanges(ranges, USE, IGNORE) // ConnLaxWhiteListPolicy
+//	PolicyFromRanges(ranges, USE, REJECT) // ConnStrictWhiteListPolicy
+//
+// Both of those combinations leave the header optional for matched peers. For
+// the spec-strict posture — trusted sources MUST send a header, everything
+// else is dropped — use TrustProxyHeaderFromRanges instead.
+func PolicyFromRanges(ranges []string, matched, unmatched Policy) (ConnPolicyFunc, error) {
+	allowFrom, err := parse(ranges)
+	if err != nil {
+		return nil, err
+	}
+
+	return connRangesPolicy(allowFrom, matched, unmatched), nil
+}
+
+// MustPolicyFromRanges returns PolicyFromRanges and panics if any entry in
+// ranges is invalid. Intended for static configuration known at program init.
+func MustPolicyFromRanges(ranges []string, matched, unmatched Policy) ConnPolicyFunc {
+	pfunc, err := PolicyFromRanges(ranges, matched, unmatched)
+	if err != nil {
+		panic(err)
+	}
+
+	return pfunc
+}
+
+func parse(allowed []string) ([]func(net.IP) bool, error) {
+	a := make([]func(net.IP) bool, len(allowed))
+	for i, allowFrom := range allowed {
+		if strings.LastIndex(allowFrom, "/") > 0 {
+			_, ipRange, err := net.ParseCIDR(allowFrom)
+			if err != nil {
+				return nil, fmt.Errorf("proxyproto: given string %q is not a valid IP range: %v", allowFrom, err)
+			}
+
+			a[i] = ipRange.Contains
+		} else {
+			allowed := net.ParseIP(allowFrom)
+			if allowed == nil {
+				return nil, fmt.Errorf("proxyproto: given string %q is not a valid IP address", allowFrom)
+			}
+
+			a[i] = allowed.Equal
+		}
+	}
+
+	return a, nil
+}
+
+func ipFromAddr(upstream net.Addr) (net.IP, error) {
+	upstreamString, _, err := net.SplitHostPort(upstream.String())
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamIP := net.ParseIP(upstreamString)
+	if nil == upstreamIP {
+		return nil, fmt.Errorf("proxyproto: invalid IP address")
+	}
+
+	return upstreamIP, nil
+}
+
+// TrustProxyHeaderFrom returns a ConnPolicyFunc implementing the spec's
+// receiver posture end to end: connections from trusted IPs MUST carry a PROXY
+// header (REQUIRE — absence fails the first Read with ErrNoProxyProtocol, so
+// header presence is never guessed), and connections from any other source are
+// dropped by Listener.Accept without stopping the listener.
+//
+// Note the REJECT policy alone cannot provide the second half: REJECT refuses
+// connections that DO send a header, but a headerless connection from an
+// untrusted peer would still be served raw, sharing the port between PROXY and
+// non-PROXY traffic — exactly what the spec's security model forbids.
+func TrustProxyHeaderFrom(trustedIPs ...net.IP) ConnPolicyFunc {
+	return func(connOpts ConnPolicyOptions) (Policy, error) {
+		ip, err := ipFromAddr(connOpts.Upstream)
+		if err != nil {
+			// Deny only this connection: wrapping ErrInvalidUpstream keeps
+			// Listener.Accept listening instead of surfacing the error and
+			// stopping the caller's accept loop.
+			return REJECT, fmt.Errorf("%w: %w", ErrInvalidUpstream, err)
+		}
+
+		for _, trustedIP := range trustedIPs {
+			if trustedIP.Equal(ip) {
+				return REQUIRE, nil
+			}
+		}
+
+		return REJECT, fmt.Errorf("%w: %s is not a trusted PROXY sender", ErrInvalidUpstream, ip)
+	}
+}
+
+// TrustProxyHeaderFromRanges is the CIDR-capable variant of
+// TrustProxyHeaderFrom, with the same spec posture: connections from the
+// trusted set MUST carry a PROXY header (REQUIRE), and connections from any
+// other source are dropped by Listener.Accept without stopping the listener.
+// Each entry in trusted may be an individual IP address ("10.0.0.10") or a
+// CIDR range ("10.0.0.0/24"); an invalid entry returns an error instead of a
+// ConnPolicyFunc.
+//
+// Unlike the *WhiteListPolicy helpers — which make the header optional (USE)
+// for allowed peers and merely ignore or refuse the header for denied ones —
+// this helper never guesses whether a header is present.
+func TrustProxyHeaderFromRanges(trusted []string) (ConnPolicyFunc, error) {
+	allowFrom, err := parse(trusted)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(connOpts ConnPolicyOptions) (Policy, error) {
+		ip, err := ipFromAddr(connOpts.Upstream)
+		if err != nil {
+			// Deny only this connection: wrapping ErrInvalidUpstream keeps
+			// Listener.Accept listening instead of surfacing the error and
+			// stopping the caller's accept loop.
+			return REJECT, fmt.Errorf("%w: %w", ErrInvalidUpstream, err)
+		}
+
+		for _, allow := range allowFrom {
+			if allow(ip) {
+				return REQUIRE, nil
+			}
+		}
+
+		return REJECT, fmt.Errorf("%w: %s is not a trusted PROXY sender", ErrInvalidUpstream, ip)
+	}, nil
+}
+
+// IgnoreProxyHeaderNotOnInterface returns a ConnPolicyFunc which can be used to
+// decide whether to use or ignore PROXY headers depending on the connection
+// being made on specific interfaces. This policy can be used when the server
+// is bound to multiple interfaces but wants to allow on one or more interfaces.
+func IgnoreProxyHeaderNotOnInterface(allowedIP net.IP) ConnPolicyFunc {
+	return func(connOpts ConnPolicyOptions) (Policy, error) {
+		ip, err := ipFromAddr(connOpts.Downstream)
+		if err != nil {
+			// The local (downstream) address cannot be classified; deny only this
+			// connection. Wrapping ErrInvalidUpstream keeps Listener.Accept
+			// listening instead of surfacing the error and stopping the caller's
+			// accept loop.
+			return REJECT, fmt.Errorf("%w: %w", ErrInvalidUpstream, err)
+		}
+
+		if allowedIP.Equal(ip) {
+			return USE, nil
+		}
+
+		return IGNORE, nil
+	}
+}

--- a/vendor/github.com/pires/go-proxyproto/protocol.go
+++ b/vendor/github.com/pires/go-proxyproto/protocol.go
@@ -1,0 +1,554 @@
+package proxyproto
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// readBufferSize is the size used for bufio.Reader's internal buffer.
+//
+// This is kept low to reduce per-connection memory overhead. If the header is
+// larger than readBufferSize, the header will be decoded with multiple Read
+// calls. For v1 the header length is at most 108 bytes. For v2 the header
+// length is at most 52 bytes plus the length of the TLVs. We use 256 bytes to
+// accommodate for the most common cases.
+const readBufferSize = 256
+
+var (
+	// DefaultReadHeaderTimeout is how long header processing waits for header to
+	// be read from the wire, if Listener.ReaderHeaderTimeout is not set.
+	// It's kept as a global variable so to make it easier to find and override,
+	// e.g. go build -ldflags -X "github.com/pires/go-proxyproto.DefaultReadHeaderTimeout=1s".
+	DefaultReadHeaderTimeout = 10 * time.Second
+
+	// ErrInvalidUpstream should be returned (possibly wrapped) by a policy
+	// function when an upstream connection address is not trusted or cannot be
+	// classified. Listener.Accept closes that connection and keeps listening;
+	// a policy error that does not wrap ErrInvalidUpstream is returned by
+	// Accept itself, which typically stops the caller's accept loop. All
+	// built-in policies wrap address-classification failures in
+	// ErrInvalidUpstream so a single unclassifiable peer cannot stop the
+	// listener.
+	ErrInvalidUpstream = fmt.Errorf("proxyproto: upstream connection address not trusted for PROXY information")
+)
+
+// Listener is used to wrap an underlying listener,
+// whose connections may be using the HAProxy Proxy Protocol.
+// If the connection is using the protocol, the RemoteAddr() will return
+// the correct client address. ReadHeaderTimeout will be applied to all
+// connections in order to prevent blocking operations. If no ReadHeaderTimeout
+// is set, a default of 10s will be used. This can be disabled by setting the
+// timeout to < 0.
+//
+// When neither Policy nor ConnPolicy is set, DefaultPolicy applies: REQUIRE,
+// so connections that do not open with a PROXY header fail their first
+// Read/Write with ErrNoProxyProtocol. Headers are still honored from ANY peer
+// under REQUIRE; a listener reachable by untrusted clients should set a
+// trusted-source policy (e.g. TrustProxyHeaderFrom or TrustProxyHeaderFromRanges).
+//
+// Listener is stream-oriented (TCP, Unix stream): the header is read once at
+// the start of the byte stream. It cannot implement the PROXY protocol over
+// UDP, where the spec requires a header parsed independently in each datagram;
+// use ParseUDPDatagram and Header.FormatUDPDatagram for that.
+//
+// Note that ReadHeaderTimeout only bounds how long a single slow connection can
+// hold a goroutine and file descriptor during header detection; it is not a
+// connection count or accept-rate limit. Deployments exposed to untrusted
+// clients should keep ReadHeaderTimeout low and enforce connection/rate limits
+// upstream (or around Accept).
+//
+// Only one of Policy or ConnPolicy should be provided. If both are provided then
+// a panic would occur during accept.
+type Listener struct {
+	// Listener is the underlying listener.
+	Listener net.Listener
+	// Deprecated: use ConnPolicyFunc instead. This will be removed in future release.
+	Policy PolicyFunc
+	// ConnPolicy is the policy function for accepted connections.
+	ConnPolicy ConnPolicyFunc
+	// ValidateHeader is the validator function for the proxy header.
+	ValidateHeader Validator
+	// ReadHeaderTimeout is the timeout for reading the proxy header.
+	ReadHeaderTimeout time.Duration
+	// ReadBufferSize is the read buffer size for accepted connections. When > 0,
+	// each accepted connection uses this size for proxy header detection; 0 means default.
+	// See the sizing note on WithBufferSize: values below 107 bytes break v1
+	// header parsing.
+	ReadBufferSize int
+}
+
+// Conn is used to wrap and underlying connection which
+// may be speaking the Proxy Protocol. If it is, the RemoteAddr() will
+// return the address of the client instead of the proxy address. Each connection
+// will have its own readHeaderTimeout and readDeadline set by the Accept() call.
+type Conn struct {
+	readDeadline atomic.Value // time.Time
+	once         sync.Once
+	readErr      error
+	conn         net.Conn
+	bufReader    *bufio.Reader
+	// bufferSize is set when the client overrides via WithBufferSize; nil means use default.
+	bufferSize        *int
+	header            *Header
+	ProxyHeaderPolicy Policy
+	Validate          Validator
+	readHeaderTimeout time.Duration
+}
+
+// Validator receives a header and decides whether it is a valid one
+// In case the header is not deemed valid it should return an error.
+type Validator func(*Header) error
+
+// ValidateHeader adds given validator for proxy headers to a connection when passed as option to NewConn().
+func ValidateHeader(v Validator) func(*Conn) {
+	return func(c *Conn) {
+		if v != nil {
+			c.Validate = v
+		}
+	}
+}
+
+// SetReadHeaderTimeout sets the readHeaderTimeout for a connection when passed as option to NewConn().
+// A value of 0 disables the header read timeout; negative values are ignored,
+// leaving the connection's current timeout (the NewConn default) in place.
+func SetReadHeaderTimeout(t time.Duration) func(*Conn) {
+	return func(c *Conn) {
+		if t >= 0 {
+			c.readHeaderTimeout = t
+		}
+	}
+}
+
+// WithBufferSize sets the size of the read buffer used for proxy header detection.
+// Values <= 0 are ignored and the default (256 bytes) is used. Values < 16 are
+// effectively 16 due to bufio's minimum. The default is tuned for typical proxy
+// protocol header lengths.
+//
+// The buffer must be able to hold an entire v1 header line (up to 107 bytes):
+// v1 parsing requires the line to be available without refilling the buffer
+// (the slow-loris defense), so a smaller buffer rejects every v1 connection
+// with ErrCantReadVersion1Header even from well-behaved senders. v2 parsing
+// refills freely and works with any size.
+func WithBufferSize(length int) func(*Conn) {
+	return func(c *Conn) {
+		if length <= 0 {
+			return
+		}
+		p := new(int)
+		*p = length
+		c.bufferSize = p
+		c.bufReader = bufio.NewReaderSize(c.conn, length)
+	}
+}
+
+// Accept waits for and returns the next valid connection to the listener.
+func (p *Listener) Accept() (net.Conn, error) {
+	for {
+		// Get the underlying connection.
+		conn, err := p.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+
+		proxyHeaderPolicy := DefaultPolicy
+		if p.Policy != nil && p.ConnPolicy != nil {
+			panic("only one of policy or connpolicy must be provided.")
+		}
+		if p.Policy != nil || p.ConnPolicy != nil {
+			if p.Policy != nil {
+				proxyHeaderPolicy, err = p.Policy(conn.RemoteAddr())
+			} else {
+				proxyHeaderPolicy, err = p.ConnPolicy(ConnPolicyOptions{
+					Upstream:   conn.RemoteAddr(),
+					Downstream: conn.LocalAddr(),
+				})
+			}
+			if err != nil {
+				// can't decide the policy, we can't accept the connection.
+				if closeErr := conn.Close(); closeErr != nil {
+					return nil, closeErr
+				}
+
+				if errors.Is(err, ErrInvalidUpstream) {
+					// keep listening for other connections.
+					continue
+				}
+
+				return nil, err
+			}
+			// Handle a connection as a regular one.
+			if proxyHeaderPolicy == SKIP {
+				return conn, nil
+			}
+		}
+
+		opts := []func(*Conn){
+			WithPolicy(proxyHeaderPolicy),
+			ValidateHeader(p.ValidateHeader),
+		}
+		if p.ReadBufferSize > 0 {
+			opts = append(opts, WithBufferSize(p.ReadBufferSize))
+		}
+		newConn := NewConn(conn, opts...)
+
+		// Set the readHeaderTimeout of the new conn to the value of the listener,
+		// falling back to the default when unset. Read into a local rather than
+		// writing back to the shared Listener: mutating p here races with
+		// concurrent Accept calls and would silently rewrite the caller's struct.
+		readHeaderTimeout := p.ReadHeaderTimeout
+		if readHeaderTimeout == 0 {
+			readHeaderTimeout = DefaultReadHeaderTimeout
+		}
+		newConn.readHeaderTimeout = readHeaderTimeout
+
+		return newConn, nil
+	}
+}
+
+// Close closes the underlying listener.
+func (p *Listener) Close() error {
+	return p.Listener.Close()
+}
+
+// Addr returns the underlying listener's network address.
+func (p *Listener) Addr() net.Addr {
+	return p.Listener.Addr()
+}
+
+// NewConn is used to wrap a net.Conn that may be speaking the PROXY protocol
+// into a proxyproto.Conn.
+//
+// Conn is stream-oriented; see the note on Listener about the PROXY protocol
+// over UDP datagrams.
+//
+// By default the returned Conn applies DefaultPolicy (REQUIRE, so the peer
+// must open with a PROXY header; override with the WithPolicy option) and
+// DefaultReadHeaderTimeout (10s) while detecting the PROXY protocol header, so
+// a client that connects but never sends data cannot make header detection
+// block forever.
+//
+// The timeout bounds header detection only, not the first Read end-to-end:
+// under a non-REQUIRE policy, when no header is present Read falls through to
+// a normal read of the underlying connection, which can still block on a
+// silent client (pinning a goroutine and file descriptor). For an end-to-end
+// bound, set a read deadline on the connection, or keep the REQUIRE policy,
+// which makes the first Read fail when no header arrives within the timeout.
+//
+// Override the timeout with the SetReadHeaderTimeout option; pass
+// SetReadHeaderTimeout(0) to disable it entirely.
+//
+// NOTE: NewConn may interfere with previously set ReadDeadline on the provided net.Conn,
+// because it sets a temporary deadline when detecting and reading the PROXY protocol header.
+// If you need to enforce a specific ReadDeadline on the connection, be sure to call Conn.SetReadDeadline
+// again after NewConn returns, to restore your desired deadline.
+func NewConn(conn net.Conn, opts ...func(*Conn)) *Conn {
+	br := bufio.NewReaderSize(conn, readBufferSize)
+
+	pConn := &Conn{
+		bufReader:         br,
+		conn:              conn,
+		ProxyHeaderPolicy: DefaultPolicy,
+		readHeaderTimeout: DefaultReadHeaderTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(pConn)
+	}
+
+	return pConn
+}
+
+// Read checks for the proxy protocol header on the first call, then reads
+// from the connection. If there is an error processing the header, it is
+// returned by this and every subsequent call. The connection is NOT closed by
+// this package; the caller should close it.
+func (p *Conn) Read(b []byte) (int, error) {
+	// Ensure header processing runs at most once and surface any errors.
+	if err := p.ensureHeaderProcessed(); err != nil {
+		return 0, err
+	}
+
+	// Drain the buffer if it exists and has data.
+	if p.bufReader != nil {
+		if p.bufReader.Buffered() > 0 {
+			n, err := p.bufReader.Read(b)
+
+			// Did we empty the buffer?
+			// Buffering a net.Conn means the buffer doesn't return io.EOF until the connection returns io.EOF.
+			// Therefore, we use Buffered() == 0 to detect if we are done with the buffer.
+			if p.bufReader.Buffered() == 0 {
+				// Garbage collect the buffer.
+				p.bufReader = nil
+			}
+
+			// Return immediately. Do not touch p.conn.
+			// If err is EOF here, it means the connection is actually closed,
+			// so we should return that error to the user anyway.
+			return n, err
+		}
+		// If buffer was empty to begin with (shouldn't happen with the >0 check
+		// but good for safety), clear it.
+		p.bufReader = nil
+	}
+
+	// From now on, read directly from the underlying connection.
+	return p.conn.Read(b)
+}
+
+// Write wraps original conn.Write.
+func (p *Conn) Write(b []byte) (int, error) {
+	// Ensure header processing has completed before writing.
+	if err := p.ensureHeaderProcessed(); err != nil {
+		return 0, err
+	}
+	return p.conn.Write(b)
+}
+
+// Close wraps original conn.Close.
+func (p *Conn) Close() error {
+	return p.conn.Close()
+}
+
+// ProxyHeader returns the proxy protocol header, if any. If an error occurs
+// while reading the proxy header, nil is returned.
+func (p *Conn) ProxyHeader() *Header {
+	// Ensure header processing runs at most once.
+	_ = p.ensureHeaderProcessed()
+	return p.header
+}
+
+// LocalAddr returns the address of the server if the proxy
+// protocol is being used, otherwise just returns the address of
+// the socket server. In case an error happens on reading the
+// proxy header the original LocalAddr is returned, not the one
+// from the proxy header even if the proxy header itself is
+// syntactically correct.
+func (p *Conn) LocalAddr() net.Addr {
+	// Ensure header processing runs at most once.
+	_ = p.ensureHeaderProcessed()
+	if p.header == nil || p.header.Command.IsLocal() || p.readErr != nil || p.header.DestinationAddr == nil {
+		return p.conn.LocalAddr()
+	}
+
+	return p.header.DestinationAddr
+}
+
+// RemoteAddr returns the address of the client if the proxy
+// protocol is being used, otherwise just returns the address of
+// the socket peer. In case an error happens on reading the
+// proxy header the original RemoteAddr is returned, not the one
+// from the proxy header even if the proxy header itself is
+// syntactically correct.
+func (p *Conn) RemoteAddr() net.Addr {
+	// Ensure header processing runs at most once.
+	_ = p.ensureHeaderProcessed()
+	if p.header == nil || p.header.Command.IsLocal() || p.readErr != nil || p.header.SourceAddr == nil {
+		return p.conn.RemoteAddr()
+	}
+
+	return p.header.SourceAddr
+}
+
+// Raw returns the underlying connection which can be casted to
+// a concrete type, allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing.
+func (p *Conn) Raw() net.Conn {
+	return p.conn
+}
+
+// TCPConn returns the underlying TCP connection,
+// allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing.
+func (p *Conn) TCPConn() (conn *net.TCPConn, ok bool) {
+	conn, ok = p.conn.(*net.TCPConn)
+	return
+}
+
+// UnixConn returns the underlying Unix socket connection,
+// allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing.
+func (p *Conn) UnixConn() (conn *net.UnixConn, ok bool) {
+	conn, ok = p.conn.(*net.UnixConn)
+	return
+}
+
+// UDPConn returns the underlying UDP connection,
+// allowing access to specialized functions.
+//
+// Use this ONLY if you know exactly what you are doing.
+func (p *Conn) UDPConn() (conn *net.UDPConn, ok bool) {
+	conn, ok = p.conn.(*net.UDPConn)
+	return
+}
+
+// SetDeadline wraps original conn.SetDeadline.
+func (p *Conn) SetDeadline(t time.Time) error {
+	p.readDeadline.Store(t)
+	return p.conn.SetDeadline(t)
+}
+
+// SetReadDeadline wraps original conn.SetReadDeadline.
+func (p *Conn) SetReadDeadline(t time.Time) error {
+	// Set a local var that tells us the desired deadline. This is
+	// needed in order to reset the read deadline to the one that is
+	// desired by the user, rather than an empty deadline.
+	p.readDeadline.Store(t)
+	return p.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline wraps original conn.SetWriteDeadline.
+func (p *Conn) SetWriteDeadline(t time.Time) error {
+	return p.conn.SetWriteDeadline(t)
+}
+
+// readHeader reads the proxy protocol header from the connection.
+func (p *Conn) readHeader() error {
+	// If the connection's readHeaderTimeout is more than 0,
+	// apply a temporary deadline without extending a user-configured
+	// deadline. If the user has no deadline, we use now + timeout.
+	if p.readHeaderTimeout > 0 {
+		var (
+			storedDeadline time.Time
+			hasDeadline    bool
+		)
+		if t := p.readDeadline.Load(); t != nil {
+			storedDeadline = t.(time.Time)
+			hasDeadline = !storedDeadline.IsZero()
+		}
+
+		headerDeadline := time.Now().Add(p.readHeaderTimeout)
+		if hasDeadline && storedDeadline.Before(headerDeadline) {
+			// Clamp to the user's earlier deadline to avoid extending it.
+			headerDeadline = storedDeadline
+		}
+
+		if err := p.conn.SetReadDeadline(headerDeadline); err != nil {
+			return err
+		}
+	}
+
+	header, err := Read(p.bufReader)
+
+	// If the connection's readHeaderTimeout is more than 0, undo the change to the
+	// deadline that we made above. Because we retain the readDeadline as part of our
+	// SetReadDeadline override, we can restore the user's deadline (if any).
+	// Therefore, we check whether the error is a net.Timeout and if it is, we decide
+	// the proxy proto does not exist and set the error accordingly.
+	if p.readHeaderTimeout > 0 {
+		t := p.readDeadline.Load()
+		if t == nil {
+			t = time.Time{}
+		}
+		// Restore the user's deadline on a best-effort basis. This must not
+		// discard a header we already parsed: some connections (notably
+		// net.Pipe) return an error from SetReadDeadline once the peer has
+		// closed, which can happen right after the peer sends the header and
+		// closes. Only surface a restore failure when the read produced neither
+		// a header nor an error of its own.
+		restoreErr := p.conn.SetReadDeadline(t.(time.Time))
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			err = ErrNoProxyProtocol
+		} else if err == nil && header == nil {
+			err = restoreErr
+		}
+	}
+
+	// For the purpose of this wrapper shamefully stolen from armon/go-proxyproto
+	// let's act as if there was no error when PROXY protocol is not present.
+	if err == ErrNoProxyProtocol {
+		// but not if it is required that the connection has one
+		if p.ProxyHeaderPolicy == REQUIRE {
+			return err
+		}
+
+		return nil
+	}
+
+	// proxy protocol header was found
+	if err == nil && header != nil {
+		switch p.ProxyHeaderPolicy {
+		case REJECT:
+			// this connection is not allowed to send one
+			return ErrSuperfluousProxyHeader
+		case USE, REQUIRE:
+			if p.Validate != nil {
+				err = p.Validate(header)
+				if err != nil {
+					return err
+				}
+			}
+
+			p.header = header
+		}
+	}
+
+	return err
+}
+
+// ensureHeaderProcessed runs header processing once.
+func (p *Conn) ensureHeaderProcessed() error {
+	p.once.Do(func() {
+		p.readErr = p.readHeader()
+	})
+	if p.readErr != nil {
+		return p.readErr
+	}
+	return nil
+}
+
+// ReadFrom implements the io.ReaderFrom ReadFrom method.
+func (p *Conn) ReadFrom(r io.Reader) (int64, error) {
+	// Ensure header processing has completed before reading/writing.
+	if err := p.ensureHeaderProcessed(); err != nil {
+		return 0, err
+	}
+	if rf, ok := p.conn.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(p.conn, r)
+}
+
+// WriteTo implements io.WriterTo.
+func (p *Conn) WriteTo(w io.Writer) (int64, error) {
+	// Ensure header processing has completed before reading/writing.
+	if err := p.ensureHeaderProcessed(); err != nil {
+		return 0, err
+	}
+
+	// If the buffer has been drained (or cleared), copy directly from conn.
+	if p.bufReader == nil {
+		return io.Copy(w, p.conn)
+	}
+
+	b := make([]byte, p.bufReader.Buffered())
+	if _, err := p.bufReader.Read(b); err != nil {
+		return 0, err // this should never happen as we read buffered data.
+	}
+
+	var n int64
+	{
+		nn, err := w.Write(b)
+		n += int64(nn)
+		if err != nil {
+			return n, err
+		}
+	}
+	{
+		nn, err := io.Copy(w, p.conn)
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}

--- a/vendor/github.com/pires/go-proxyproto/tlv.go
+++ b/vendor/github.com/pires/go-proxyproto/tlv.go
@@ -1,0 +1,147 @@
+// Type-Length-Value splitting and parsing for proxy protocol V2.
+// See spec https://www.haproxy.org/download/3.4/doc/proxy-protocol.txt sections 2.2 to 2.2.8.
+
+package proxyproto
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// TLV type constants defined by the PROXY protocol spec.
+//
+//nolint:revive // Names follow the spec.
+const (
+	// Section 2.2.
+	PP2_TYPE_ALPN               PP2Type = 0x01
+	PP2_TYPE_AUTHORITY          PP2Type = 0x02
+	PP2_TYPE_CRC32C             PP2Type = 0x03
+	PP2_TYPE_NOOP               PP2Type = 0x04
+	PP2_TYPE_UNIQUE_ID          PP2Type = 0x05
+	PP2_TYPE_SSL                PP2Type = 0x20
+	PP2_SUBTYPE_SSL_VERSION     PP2Type = 0x21
+	PP2_SUBTYPE_SSL_CN          PP2Type = 0x22
+	PP2_SUBTYPE_SSL_CIPHER      PP2Type = 0x23
+	PP2_SUBTYPE_SSL_SIG_ALG     PP2Type = 0x24
+	PP2_SUBTYPE_SSL_KEY_ALG     PP2Type = 0x25
+	PP2_SUBTYPE_SSL_GROUP       PP2Type = 0x26
+	PP2_SUBTYPE_SSL_SIG_SCHEME  PP2Type = 0x27
+	PP2_SUBTYPE_SSL_CLIENT_CERT PP2Type = 0x28
+	PP2_TYPE_NETNS              PP2Type = 0x30
+
+	// Section 2.2.8, reserved types.
+	PP2_TYPE_MIN_CUSTOM     PP2Type = 0xE0
+	PP2_TYPE_MAX_CUSTOM     PP2Type = 0xEF
+	PP2_TYPE_MIN_EXPERIMENT PP2Type = 0xF0
+	PP2_TYPE_MAX_EXPERIMENT PP2Type = 0xF7
+	PP2_TYPE_MIN_FUTURE     PP2Type = 0xF8
+	PP2_TYPE_MAX_FUTURE     PP2Type = 0xFF
+)
+
+var (
+	// ErrTruncatedTLV indicates a TLV was truncated.
+	ErrTruncatedTLV = errors.New("proxyproto: truncated TLV")
+	// ErrMalformedTLV indicates a TLV has malformed data.
+	ErrMalformedTLV = errors.New("proxyproto: malformed TLV Value")
+	// ErrIncompatibleTLV indicates a TLV is of an unexpected type.
+	ErrIncompatibleTLV = errors.New("proxyproto: incompatible TLV type")
+)
+
+// PP2Type is the proxy protocol v2 type.
+type PP2Type byte
+
+// TLV is a uninterpreted Type-Length-Value for V2 protocol, see section 2.2.
+type TLV struct {
+	Type  PP2Type
+	Value []byte
+}
+
+// SplitTLVs splits the Type-Length-Value vector, returns the vector or an error.
+func SplitTLVs(raw []byte) ([]TLV, error) {
+	var tlvs []TLV
+	for i := 0; i < len(raw); {
+		tlv := TLV{
+			Type: PP2Type(raw[i]),
+		}
+		if len(raw)-i <= 2 {
+			return nil, ErrTruncatedTLV
+		}
+		tlvLen := int(binary.BigEndian.Uint16(raw[i+1 : i+3])) // Max length = 65K
+		i += 3
+		if i+tlvLen > len(raw) {
+			return nil, ErrTruncatedTLV
+		}
+		// Ignore no-op padding
+		if tlv.Type != PP2_TYPE_NOOP {
+			tlv.Value = make([]byte, tlvLen)
+			copy(tlv.Value, raw[i:i+tlvLen])
+		}
+		i += tlvLen
+		tlvs = append(tlvs, tlv)
+	}
+	return tlvs, nil
+}
+
+// JoinTLVs joins multiple Type-Length-Value records.
+func JoinTLVs(tlvs []TLV) ([]byte, error) {
+	var raw []byte
+	for _, tlv := range tlvs {
+		if len(tlv.Value) > math.MaxUint16 {
+			return nil, fmt.Errorf("proxyproto: cannot format TLV %v with length %d", tlv.Type, len(tlv.Value))
+		}
+		var length [2]byte
+		//nolint:gosec // lengthValue is validated above.
+		lengthValue := uint16(len(tlv.Value))
+		binary.BigEndian.PutUint16(length[:], lengthValue)
+		raw = append(raw, byte(tlv.Type))
+		raw = append(raw, length[:]...)
+		raw = append(raw, tlv.Value...)
+	}
+	return raw, nil
+}
+
+// Registered is true if the type is registered in the spec, see section 2.2.
+func (p PP2Type) Registered() bool {
+	switch p {
+	case PP2_TYPE_ALPN,
+		PP2_TYPE_AUTHORITY,
+		PP2_TYPE_CRC32C,
+		PP2_TYPE_NOOP,
+		PP2_TYPE_UNIQUE_ID,
+		PP2_TYPE_SSL,
+		PP2_SUBTYPE_SSL_VERSION,
+		PP2_SUBTYPE_SSL_CN,
+		PP2_SUBTYPE_SSL_CIPHER,
+		PP2_SUBTYPE_SSL_SIG_ALG,
+		PP2_SUBTYPE_SSL_KEY_ALG,
+		PP2_SUBTYPE_SSL_GROUP,
+		PP2_SUBTYPE_SSL_SIG_SCHEME,
+		PP2_SUBTYPE_SSL_CLIENT_CERT,
+		PP2_TYPE_NETNS:
+		return true
+	}
+	return false
+}
+
+// App is true if the type is reserved for application specific data, see section 2.2.8.
+func (p PP2Type) App() bool {
+	return p >= PP2_TYPE_MIN_CUSTOM && p <= PP2_TYPE_MAX_CUSTOM
+}
+
+// Experiment is true if the type is reserved for temporary experimental use by application
+// developers, see section 2.2.8.
+func (p PP2Type) Experiment() bool {
+	return p >= PP2_TYPE_MIN_EXPERIMENT && p <= PP2_TYPE_MAX_EXPERIMENT
+}
+
+// Future is true is the type is reserved for future use, see section 2.2.8.
+func (p PP2Type) Future() bool {
+	return p >= PP2_TYPE_MIN_FUTURE
+}
+
+// Spec is true if the type is covered by the spec, see section 2.2 and 2.2.8.
+func (p PP2Type) Spec() bool {
+	return p.Registered() || p.App() || p.Experiment() || p.Future()
+}

--- a/vendor/github.com/pires/go-proxyproto/udp.go
+++ b/vendor/github.com/pires/go-proxyproto/udp.go
@@ -1,0 +1,49 @@
+package proxyproto
+
+import (
+	"bufio"
+	"bytes"
+)
+
+// ParseUDPDatagram parses a PROXY protocol header at the start of a UDP
+// datagram and returns the header together with the proxied payload that
+// follows it. The returned payload aliases the datagram slice.
+//
+// Per spec (section 2), when the PROXY protocol is carried over UDP the header
+// and the proxied payload MUST be sent in the same datagram, and the receiver
+// MUST parse the header independently for each received datagram. Call this
+// for every datagram received; there is no connection state to carry over.
+// Conn and Listener are stream-oriented and cannot provide those semantics.
+//
+// A datagram that does not begin with a complete, valid header fails with the
+// same errors Read returns — ErrNoProxyProtocol when the signature is absent.
+// The spec forbids guessing whether a header is present, so on a receiver
+// configured for the PROXY protocol such datagrams must be dropped, not
+// treated as raw payload.
+func ParseUDPDatagram(datagram []byte) (*Header, []byte, error) {
+	byteReader := bytes.NewReader(datagram)
+	// Size the buffer to the whole datagram so the header is fully buffered up
+	// front: v1 parsing aborts if the header is not available in a single read,
+	// and a datagram, unlike a stream, can never deliver more bytes later.
+	// bufio enforces a minimum buffer size internally, covering len == 0.
+	reader := bufio.NewReaderSize(byteReader, len(datagram))
+	header, err := Read(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	consumed := len(datagram) - reader.Buffered() - byteReader.Len()
+	return header, datagram[consumed:], nil
+}
+
+// FormatUDPDatagram renders the header followed by the proxied payload,
+// producing the exact bytes to send as one UDP datagram. Per spec (section 2)
+// the header and the payload MUST share a single datagram, which a single
+// write of the returned slice guarantees; formatting the header and payload
+// separately risks a sender splitting them across datagrams.
+func (header *Header) FormatUDPDatagram(payload []byte) ([]byte, error) {
+	buf, err := header.Format()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, payload...), nil
+}

--- a/vendor/github.com/pires/go-proxyproto/v1.go
+++ b/vendor/github.com/pires/go-proxyproto/v1.go
@@ -1,0 +1,316 @@
+package proxyproto
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+const (
+	crlf      = "\r\n"
+	separator = " "
+
+	// v1ProtoTCP4 and v1ProtoTCP6 are the PROXY protocol v1 transport-protocol
+	// tokens for TCP over IPv4 and IPv6 respectively (net has no constants for
+	// these textual identifiers).
+	v1ProtoTCP4 = "TCP4"
+	v1ProtoTCP6 = "TCP6"
+)
+
+// V1AcceptIPv4InTCP6 permits plain IPv4 literals in the address fields of a v1
+// TCP6 line, promoting them to v4-mapped IPv6 (::ffff:x.x.x.x). Some proxies
+// (notably the nginx OSS stream module) emit such lines when the client and
+// backend address families differ. The spec forbids them — "the advertised
+// protocol family dictates what format to use" — so this compatibility mode is
+// disabled by default.
+//
+// Note the promotion is lossy: round-trip serialization renders the address as
+// "::ffff:x.x.x.x" rather than the original "x.x.x.x".
+//
+// Like DefaultReadHeaderTimeout, this is a package-level variable to keep it
+// easy to override. Set it at program init; it must not be modified
+// concurrently with parsing.
+var V1AcceptIPv4InTCP6 = false
+
+func initVersion1() *Header {
+	header := new(Header)
+	header.Version = 1
+	// Command doesn't exist in v1
+	header.Command = PROXY
+	return header
+}
+
+func parseVersion1(reader *bufio.Reader) (*Header, error) {
+	//The header cannot be more than 107 bytes long. Per spec:
+	//
+	//   (...)
+	//   - worst case (optional fields set to 0xff) :
+	//     "PROXY UNKNOWN ffff:f...f:ffff ffff:f...f:ffff 65535 65535\r\n"
+	//     => 5 + 1 + 7 + 1 + 39 + 1 + 39 + 1 + 5 + 1 + 5 + 2 = 107 chars
+	//
+	//   So a 108-byte buffer is always enough to store all the line and a
+	//   trailing zero for string processing.
+	//
+	// It must also be CRLF terminated, as above. The header does not otherwise
+	// contain a CR or LF byte.
+	//
+	// ISSUE #69
+	// We can't use Peek here as it will block trying to fill the buffer, which
+	// will never happen if the header is TCP4 or TCP6 (max. 56 and 104 bytes
+	// respectively) and the server is expected to speak first.
+	//
+	// Similarly, we can't use ReadString or ReadBytes as these will keep reading
+	// until the delimiter is found; an abusive client could easily disrupt a
+	// server by sending a large amount of data that do not contain a LF byte.
+	// Another means of attack would be to start connections and simply not send
+	// data after the initial PROXY signature bytes, accumulating a large
+	// number of blocked goroutines on the server. ReadSlice will also block for
+	// a delimiter when the internal buffer does not fill up.
+	//
+	// A plain Read is also problematic since we risk reading past the end of the
+	// header without being able to easily put the excess bytes back into the reader's
+	// buffer (with the current implementation's design).
+	//
+	// So we use a ReadByte loop, which solves the overflow problem and avoids
+	// reading beyond the end of the header. However, we need one more trick to harden
+	// against partial header attacks (slow loris) - per spec:
+	//
+	//    (..) The sender must always ensure that the header is sent at once, so that
+	//    the transport layer maintains atomicity along the path to the receiver. The
+	//    receiver may be tolerant to partial headers or may simply drop the connection
+	//    when receiving a partial header. Recommendation is to be tolerant, but
+	//    implementation constraints may not always easily permit this.
+	//
+	// We are subject to such implementation constraints. So we return an error if
+	// the header cannot be fully extracted with a single read of the underlying
+	// reader.
+	buf := make([]byte, 0, 107)
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrCantReadVersion1Header, err)
+		}
+		buf = append(buf, b)
+		if b == '\n' {
+			// End of header found
+			break
+		}
+		if len(buf) == 107 {
+			// No delimiter in first 107 bytes
+			return nil, ErrVersion1HeaderTooLong
+		}
+		if reader.Buffered() == 0 {
+			// Header was not buffered in a single read. Since we can't
+			// differentiate between genuine slow writers and DoS agents,
+			// we abort. On healthy networks, this should never happen.
+			return nil, ErrCantReadVersion1Header
+		}
+	}
+
+	// Check for CR before LF.
+	if len(buf) < 2 || buf[len(buf)-2] != '\r' {
+		return nil, ErrLineMustEndWithCrlf
+	}
+
+	// Check full signature. Read dispatches to this parser after peeking only
+	// the first 5 bytes ("PROXY"), so the first token must still be checked to
+	// be exactly "PROXY": per spec the line starts with "PROXY" followed by
+	// exactly one space, and anything else (e.g. "PROXYjunk TCP4 ...") is not a
+	// v1 header.
+	tokens := strings.Split(string(buf[:len(buf)-2]), separator)
+	if tokens[0] != "PROXY" {
+		return nil, ErrCantReadVersion1Header
+	}
+
+	// Expect at least 2 tokens: "PROXY" and the transport protocol.
+	if len(tokens) < 2 {
+		return nil, ErrCantReadAddressFamilyAndProtocol
+	}
+
+	// Read address family and protocol
+	var transportProtocol AddressFamilyAndProtocol
+	switch tokens[1] {
+	case v1ProtoTCP4:
+		transportProtocol = TCPv4
+	case v1ProtoTCP6:
+		transportProtocol = TCPv6
+	case "UNKNOWN":
+		transportProtocol = UNSPEC // doesn't exist in v1 but fits UNKNOWN
+	default:
+		return nil, ErrCantReadAddressFamilyAndProtocol
+	}
+
+	// Expect exactly 6 tokens when UNKNOWN is not present. The spec's TCP4/TCP6
+	// line is "PROXY <proto> <src> <dst> <sport> <dport>"; trailing tokens are
+	// not permitted. (UNKNOWN is handled leniently below, per spec: the receiver
+	// must ignore anything up to the CRLF.)
+	if transportProtocol != UNSPEC && len(tokens) != 6 {
+		return nil, ErrCantReadAddressFamilyAndProtocol
+	}
+
+	// When a signature is found, allocate a v1 header with Command set to PROXY.
+	// Command doesn't exist in v1 but set it for other parts of this library
+	// to rely on it for determining connection details.
+	header := initVersion1()
+
+	// Transport protocol has been processed already.
+	header.TransportProtocol = transportProtocol
+
+	// When UNKNOWN, set the command to LOCAL and return early
+	if header.TransportProtocol == UNSPEC {
+		header.Command = LOCAL
+		return header, nil
+	}
+
+	// Otherwise, continue to read addresses and ports
+	sourceIP, err := parseV1IPAddress(header.TransportProtocol, tokens[2])
+	if err != nil {
+		return nil, err
+	}
+	destIP, err := parseV1IPAddress(header.TransportProtocol, tokens[3])
+	if err != nil {
+		return nil, err
+	}
+	sourcePort, err := parseV1PortNumber(tokens[4])
+	if err != nil {
+		return nil, err
+	}
+	destPort, err := parseV1PortNumber(tokens[5])
+	if err != nil {
+		return nil, err
+	}
+	header.SourceAddr = &net.TCPAddr{
+		IP:   sourceIP,
+		Port: sourcePort,
+	}
+	header.DestinationAddr = &net.TCPAddr{
+		IP:   destIP,
+		Port: destPort,
+	}
+
+	return header, nil
+}
+
+func (header *Header) formatVersion1() ([]byte, error) {
+	// As of version 1, only "TCP4" ( \x54 \x43 \x50 \x34 ) for TCP over IPv4,
+	// and "TCP6" ( \x54 \x43 \x50 \x36 ) for TCP over IPv6 are allowed.
+	var proto string
+	switch header.TransportProtocol {
+	case TCPv4:
+		proto = v1ProtoTCP4
+	case TCPv6:
+		proto = v1ProtoTCP6
+	default:
+		// Unknown connection (short form)
+		return []byte("PROXY UNKNOWN" + crlf), nil
+	}
+
+	sourceAddr, sourceOK := header.SourceAddr.(*net.TCPAddr)
+	destAddr, destOK := header.DestinationAddr.(*net.TCPAddr)
+	if !sourceOK || !destOK {
+		return nil, ErrInvalidAddress
+	}
+
+	// A hand-built header can carry any int; the spec requires ports in the
+	// decimal range 0..65535, so validate before serializing (mirrors the v2
+	// port check in formatVersion2).
+	if sourceAddr.Port < 0 || sourceAddr.Port > math.MaxUint16 || destAddr.Port < 0 || destAddr.Port > math.MaxUint16 {
+		return nil, ErrInvalidPortNumber
+	}
+
+	// netip.Addr (not net.IP) is used here so String() honors the address family
+	// declared by TransportProtocol. AddrFromSlice reports ok=false when the slice
+	// is nil (e.g. To4() on an IPv6-only address), which the guard below rejects.
+	var sourceIP, destIP netip.Addr
+	switch header.TransportProtocol {
+	case TCPv4:
+		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To4())
+		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To4())
+	case TCPv6:
+		// Use netip.Addr instead of net.IP to guarantee an Is6() address; i.e. a
+		// v4-mapped IP in a TCP6 header serializes as ::ffff:1.2.3.4 instead of
+		// net.IP.String()'s collapsed 1.2.3.4.
+		sourceIP, sourceOK = netip.AddrFromSlice(sourceAddr.IP.To16())
+		destIP, destOK = netip.AddrFromSlice(destAddr.IP.To16())
+	default:
+		// Unreachable today: the proto switch at the top of this function already
+		// returns for anything other than TCPv4/TCPv6. Kept so a future protocol
+		// can't fall through with zero-value IPs while sourceOK/destOK still hold
+		// from the type assertion above.
+		return nil, ErrInvalidAddress
+	}
+	if !sourceOK || !destOK {
+		return nil, ErrInvalidAddress
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, 108))
+	buf.Write(SIGV1)
+	buf.WriteString(separator)
+	buf.WriteString(proto)
+	buf.WriteString(separator)
+	buf.WriteString(sourceIP.String())
+	buf.WriteString(separator)
+	buf.WriteString(destIP.String())
+	buf.WriteString(separator)
+	buf.WriteString(strconv.Itoa(sourceAddr.Port))
+	buf.WriteString(separator)
+	buf.WriteString(strconv.Itoa(destAddr.Port))
+	buf.WriteString(crlf)
+
+	return buf.Bytes(), nil
+}
+
+func parseV1PortNumber(portStr string) (int, error) {
+	// Per spec, a v1 port is 1..5 decimal digits in the range 0..65535, with no
+	// leading zero and no sign. ParseUint with bitSize 16 enforces all of that
+	// (it rejects empty strings, signs, non-digits, and values above 65535)
+	// except the leading zero ("080"), which the spec forbids and which creates
+	// ambiguity for anything downstream that re-parses the address.
+	if len(portStr) > 1 && portStr[0] == '0' {
+		return 0, ErrInvalidPortNumber
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", ErrInvalidPortNumber, err)
+	}
+	return int(port), nil
+}
+
+func parseV1IPAddress(protocol AddressFamilyAndProtocol, addrStr string) (net.IP, error) {
+	addr, err := netip.ParseAddr(addrStr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidAddress, err)
+	}
+	// netip accepts zoned literals ("fe80::1%eth0"). The spec's address grammar
+	// does not (hex digits and colons only), and net.IP cannot carry a zone, so
+	// accepting one would silently forward an address the sender never wrote.
+	// Per spec, "any sequence which does not exactly match the protocol must be
+	// discarded".
+	if addr.Zone() != "" {
+		return nil, ErrInvalidAddress
+	}
+
+	switch protocol {
+	case TCPv4:
+		if addr.Is4() {
+			return net.IP(addr.AsSlice()), nil
+		}
+	case TCPv6:
+		if addr.Is6() || addr.Is4In6() {
+			return net.IP(addr.AsSlice()), nil
+		}
+		// Plain IPv4 in a TCP6 line is spec-invalid but emitted by some proxies;
+		// see V1AcceptIPv4InTCP6 for the compatibility trade-off.
+		if V1AcceptIPv4InTCP6 && addr.Is4() {
+			mapped := netip.AddrFrom16(addr.As16())
+			return net.IP(mapped.AsSlice()), nil
+		}
+	}
+
+	return nil, ErrInvalidAddress
+}

--- a/vendor/github.com/pires/go-proxyproto/v2.go
+++ b/vendor/github.com/pires/go-proxyproto/v2.go
@@ -1,0 +1,357 @@
+package proxyproto
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+)
+
+// MaxV2HeaderSize is the maximum accepted value of a v2 header's 16-bit length
+// field, i.e. the number of bytes following the fixed 16-byte prefix (address
+// block plus TLVs).
+//
+// The spec allows up to 65535, but parseVersion2 allocates this many bytes
+// before reading, so a lower limit mitigates memory-allocation DoS from
+// untrusted peers while allowing real-world legitimate headers.
+// PP2_SUBTYPE_SSL_CLIENT_CERT (a DER-encoded certificate) is typically between
+// 1 and 2KiB, so the 4KiB default leaves room for other TLVs; deployments
+// expecting larger headers may raise it.
+//
+// Like DefaultReadHeaderTimeout, this is a package-level variable to keep it
+// easy to override. Set it at program init; it must not be modified
+// concurrently with parsing.
+var MaxV2HeaderSize uint16 = 4096
+
+var (
+	lengthUnspec      = uint16(0)
+	lengthV4          = uint16(12)
+	lengthV6          = uint16(36)
+	lengthUnix        = uint16(216)
+	lengthUnspecBytes = func() []byte {
+		a := make([]byte, 2)
+		binary.BigEndian.PutUint16(a, lengthUnspec)
+		return a
+	}()
+	lengthV4Bytes = func() []byte {
+		a := make([]byte, 2)
+		binary.BigEndian.PutUint16(a, lengthV4)
+		return a
+	}()
+	lengthV6Bytes = func() []byte {
+		a := make([]byte, 2)
+		binary.BigEndian.PutUint16(a, lengthV6)
+		return a
+	}()
+	lengthUnixBytes = func() []byte {
+		a := make([]byte, 2)
+		binary.BigEndian.PutUint16(a, lengthUnix)
+		return a
+	}()
+	errUint16Overflow = errors.New("proxyproto: uint16 overflow")
+)
+
+type _ports struct {
+	SrcPort uint16
+	DstPort uint16
+}
+
+type _addr4 struct {
+	Src     [4]byte
+	Dst     [4]byte
+	SrcPort uint16
+	DstPort uint16
+}
+
+type _addr6 struct {
+	Src [16]byte
+	Dst [16]byte
+	_ports
+}
+
+type _addrUnix struct {
+	Src [108]byte
+	Dst [108]byte
+}
+
+func parseVersion2(reader *bufio.Reader) (header *Header, err error) {
+	// Skip first 12 bytes (signature)
+	for range 12 {
+		if _, err = reader.ReadByte(); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrCantReadProtocolVersionAndCommand, err)
+		}
+	}
+
+	header = new(Header)
+	header.Version = 2
+
+	// Read the 13th byte, protocol version and command
+	b13, err := reader.ReadByte()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCantReadProtocolVersionAndCommand, err)
+	}
+	header.Command = ProtocolVersionAndCommand(b13)
+	if _, ok := supportedCommand[header.Command]; !ok {
+		return nil, ErrUnsupportedProtocolVersionAndCommand
+	}
+
+	// Read the 14th byte, address family and protocol
+	b14, err := reader.ReadByte()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCantReadAddressFamilyAndProtocol, err)
+	}
+	header.TransportProtocol = AddressFamilyAndProtocol(b14)
+	// Per spec (section 2.2) only the listed address family / transport protocol
+	// combinations are defined; "other values are unspecified and must not be
+	// emitted in version 2 of this protocol and must be rejected as invalid by
+	// receivers". That mandate has no command carve-out, so it applies to LOCAL
+	// too: the family byte is ignored when interpreting a LOCAL address block,
+	// but an undefined byte still makes the frame invalid. Rejecting bytes that
+	// share a known family with an undefined transport — e.g. 0x13 (IPv4
+	// family, transport 3) — also matters for PROXY: such a byte passes the
+	// IsIPv4/IsIPv6 checks below, has an address struct read for it, and then
+	// yields a nil net.Addr from newIPAddr. That nil is stored as
+	// SourceAddr/DestinationAddr and panics any caller that does
+	// RemoteAddr().String() (e.g. logging), a remotely triggerable crash.
+	if !supportedTransportProtocol[header.TransportProtocol] {
+		return nil, ErrUnsupportedAddressFamilyAndProtocol
+	}
+	// UNSPEC carries no address block to trust. For LOCAL it is the family the
+	// spec expects senders to use; for PROXY the spec leaves it to the receiver
+	// to accept or reject, and this library rejects it.
+	if header.TransportProtocol == UNSPEC && header.Command != LOCAL {
+		return nil, ErrUnsupportedAddressFamilyAndProtocol
+	}
+
+	// Make sure there are bytes available as specified in length
+	var length uint16
+	if err := binary.Read(reader, binary.BigEndian, &length); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCantReadLength, err)
+	}
+
+	if !header.validateLength(length) {
+		// A LOCAL connection is one the proxy opened itself (e.g. health
+		// checks). Per spec (section 2.2) the receiver must use the real
+		// connection endpoints (Conn.RemoteAddr/LocalAddr short-circuit on
+		// IsLocal), must skip exactly `length` bytes, and "must not assume zero
+		// is presented for LOCAL connections". So a LOCAL frame whose length
+		// does not fit its declared family's address-block layout — e.g.
+		// LOCAL + TCPv4 + length 0 — is still valid: skip the block, which the
+		// spec says to discard, and normalize the header to UNSPEC so it stays
+		// serializable via Format/WriteTo. A LOCAL frame whose length does fit
+		// the family layout is instead decoded exactly like a PROXY frame
+		// below, preserving the (informational) addresses and any trailing
+		// TLVs, so the header round-trips byte for byte.
+		if header.Command == LOCAL {
+			if length > MaxV2HeaderSize {
+				return nil, ErrInvalidLength
+			}
+			if _, err := reader.Discard(int(length)); err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidLength, err)
+			}
+			header.TransportProtocol = UNSPEC
+			return header, nil
+		}
+		return nil, ErrInvalidLength
+	}
+
+	// Return early if the length is zero, which means that
+	// there's no address information and TLVs present for UNSPEC.
+	if length == 0 {
+		return header, nil
+	}
+
+	if length > MaxV2HeaderSize {
+		return nil, ErrInvalidLength
+	}
+
+	// Length-limited reader for payload section
+	payloadReader := io.LimitReader(reader, int64(length)).(*io.LimitedReader)
+
+	// Read addresses and ports for protocols other than UNSPEC.
+	// Ignore address information for UNSPEC, and skip straight to read TLVs,
+	// since the length is greater than zero.
+	if header.TransportProtocol != UNSPEC {
+		if header.TransportProtocol.IsIPv4() {
+			var addr _addr4
+			if err := binary.Read(payloadReader, binary.BigEndian, &addr); err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidAddress, err)
+			}
+			header.SourceAddr = newIPAddr(header.TransportProtocol, addr.Src[:], addr.SrcPort)
+			header.DestinationAddr = newIPAddr(header.TransportProtocol, addr.Dst[:], addr.DstPort)
+		} else if header.TransportProtocol.IsIPv6() {
+			var addr _addr6
+			if err := binary.Read(payloadReader, binary.BigEndian, &addr); err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidAddress, err)
+			}
+			header.SourceAddr = newIPAddr(header.TransportProtocol, addr.Src[:], addr.SrcPort)
+			header.DestinationAddr = newIPAddr(header.TransportProtocol, addr.Dst[:], addr.DstPort)
+		} else if header.TransportProtocol.IsUnix() {
+			var addr _addrUnix
+			if err := binary.Read(payloadReader, binary.BigEndian, &addr); err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidAddress, err)
+			}
+
+			network := networkUnix
+			if header.TransportProtocol.IsDatagram() {
+				network = networkUnixgram
+			}
+
+			header.SourceAddr = &net.UnixAddr{
+				Net:  network,
+				Name: parseUnixName(addr.Src[:]),
+			}
+			header.DestinationAddr = &net.UnixAddr{
+				Net:  network,
+				Name: parseUnixName(addr.Dst[:]),
+			}
+		}
+	}
+
+	// Copy bytes for optional Type-Length-Value vector
+	header.rawTLVs = make([]byte, payloadReader.N) // Allocate minimum size slice
+	if _, err = io.ReadFull(payloadReader, header.rawTLVs); err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	if payloadReader.N != 0 {
+		return nil, ErrInvalidLength
+	}
+
+	return header, nil
+}
+
+func (header *Header) formatVersion2() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write(SIGV2)
+	buf.WriteByte(header.Command.toByte())
+	buf.WriteByte(header.TransportProtocol.toByte())
+	if header.TransportProtocol.IsUnspec() {
+		// For UNSPEC, write no addresses and ports but only TLVs if they are present
+		hdrLen, err := addTLVLen(lengthUnspecBytes, len(header.rawTLVs))
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(hdrLen)
+	} else {
+		var addrSrc, addrDst []byte
+		if header.TransportProtocol.IsIPv4() {
+			hdrLen, err := addTLVLen(lengthV4Bytes, len(header.rawTLVs))
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(hdrLen)
+			sourceIP, destIP, _ := header.IPs()
+			addrSrc = sourceIP.To4()
+			addrDst = destIP.To4()
+		} else if header.TransportProtocol.IsIPv6() {
+			hdrLen, err := addTLVLen(lengthV6Bytes, len(header.rawTLVs))
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(hdrLen)
+			sourceIP, destIP, _ := header.IPs()
+			addrSrc = sourceIP.To16()
+			addrDst = destIP.To16()
+		} else if header.TransportProtocol.IsUnix() {
+			hdrLen, err := addTLVLen(lengthUnixBytes, len(header.rawTLVs))
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(hdrLen)
+			sourceAddr, destAddr, ok := header.UnixAddrs()
+			if !ok {
+				return nil, ErrInvalidAddress
+			}
+			addrSrc = formatUnixName(sourceAddr.Name)
+			addrDst = formatUnixName(destAddr.Name)
+		}
+
+		if addrSrc == nil || addrDst == nil {
+			return nil, ErrInvalidAddress
+		}
+		buf.Write(addrSrc)
+		buf.Write(addrDst)
+
+		if sourcePort, destPort, ok := header.Ports(); ok {
+			if sourcePort < 0 || sourcePort > math.MaxUint16 || destPort < 0 || destPort > math.MaxUint16 {
+				return nil, ErrInvalidPortNumber
+			}
+			portBytes := make([]byte, 2)
+
+			//nolint:gosec // Bounds are checked above.
+			binary.BigEndian.PutUint16(portBytes, uint16(sourcePort))
+			buf.Write(portBytes)
+
+			//nolint:gosec // Bounds are checked above.
+			binary.BigEndian.PutUint16(portBytes, uint16(destPort))
+			buf.Write(portBytes)
+		}
+	}
+
+	if len(header.rawTLVs) > 0 {
+		buf.Write(header.rawTLVs)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (header *Header) validateLength(length uint16) bool {
+	if header.TransportProtocol.IsIPv4() {
+		return length >= lengthV4
+	} else if header.TransportProtocol.IsIPv6() {
+		return length >= lengthV6
+	} else if header.TransportProtocol.IsUnix() {
+		return length >= lengthUnix
+	} else if header.TransportProtocol.IsUnspec() {
+		return length >= lengthUnspec
+	}
+	return false
+}
+
+// addTLVLen adds the length of the TLV to the header length or errors on uint16 overflow.
+func addTLVLen(cur []byte, tlvLen int) ([]byte, error) {
+	if tlvLen == 0 {
+		return cur, nil
+	}
+	curLen := binary.BigEndian.Uint16(cur)
+	newLen := int(curLen) + tlvLen
+	if newLen >= 1<<16 {
+		return nil, errUint16Overflow
+	}
+	a := make([]byte, 2)
+	//nolint:gosec // newLen bounds are validated above.
+	binary.BigEndian.PutUint16(a, uint16(newLen))
+	return a, nil
+}
+
+func newIPAddr(transport AddressFamilyAndProtocol, ip net.IP, port uint16) net.Addr {
+	if transport.IsStream() {
+		return &net.TCPAddr{IP: ip, Port: int(port)}
+	}
+	if transport.IsDatagram() {
+		return &net.UDPAddr{IP: ip, Port: int(port)}
+	}
+	return nil
+}
+
+func parseUnixName(b []byte) string {
+	before, _, ok := bytes.Cut(b, []byte{0})
+	if !ok {
+		return string(b)
+	}
+	return string(before)
+}
+
+func formatUnixName(name string) []byte {
+	n := int(lengthUnix) / 2
+	if len(name) >= n {
+		return []byte(name[:n])
+	}
+	pad := make([]byte, n-len(name))
+	return append([]byte(name), pad...)
+}

--- a/vendor/github.com/pires/go-proxyproto/version_cmd.go
+++ b/vendor/github.com/pires/go-proxyproto/version_cmd.go
@@ -1,0 +1,48 @@
+package proxyproto
+
+// ProtocolVersionAndCommand represents the command in proxy protocol v2.
+// Command doesn't exist in v1 but it should be set since other parts of
+// this library may rely on it for determining connection details.
+type ProtocolVersionAndCommand byte
+
+const (
+	// LOCAL represents the LOCAL command in v2 or UNKNOWN transport in v1,
+	// in which case no address information is expected.
+	LOCAL ProtocolVersionAndCommand = '\x20'
+	// PROXY represents the PROXY command in v2 or transport is not UNKNOWN in v1,
+	// in which case valid local/remote address and port information is expected.
+	PROXY ProtocolVersionAndCommand = '\x21'
+)
+
+var supportedCommand = map[ProtocolVersionAndCommand]bool{
+	LOCAL: true,
+	PROXY: true,
+}
+
+// IsLocal returns true if the command in v2 is LOCAL or the transport in v1 is UNKNOWN,
+// i.e. when no address information is expected, false otherwise.
+func (pvc ProtocolVersionAndCommand) IsLocal() bool {
+	return LOCAL == pvc
+}
+
+// IsProxy returns true if the command in v2 is PROXY or the transport in v1 is not UNKNOWN,
+// i.e. when valid local/remote address and port information is expected, false otherwise.
+func (pvc ProtocolVersionAndCommand) IsProxy() bool {
+	return PROXY == pvc
+}
+
+// IsUnspec returns true if the command is unspecified, false otherwise.
+func (pvc ProtocolVersionAndCommand) IsUnspec() bool {
+	// Must be LOCAL or PROXY.
+	return !pvc.IsLocal() && !pvc.IsProxy()
+}
+
+func (pvc ProtocolVersionAndCommand) toByte() byte {
+	if pvc.IsLocal() {
+		return byte(LOCAL)
+	} else if pvc.IsProxy() {
+		return byte(PROXY)
+	}
+
+	return byte(LOCAL)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,6 +41,9 @@ github.com/mjl-/sherpats/cmd/sherpats
 # github.com/mjl-/xfmt v0.0.2
 ## explicit; go 1.12
 github.com/mjl-/xfmt
+# github.com/pires/go-proxyproto v0.15.0
+## explicit; go 1.25.0
+github.com/pires/go-proxyproto
 # github.com/prometheus/client_golang v1.18.0
 ## explicit; go 1.19
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
Add support for PROXY Protocol, which allows us to use non-standard ports in some cases, and proxy them with HAProxy or OpenResty.

This is useful when the mox server cannot directly listen on the standard mail ports, for example because they are blocked by the ISP, and another server is used as a TCP proxy. It would also be useful for clustered deployments.

Also, closes #370 