### PR TITLE
message: don't fail the preview on a line longer than the scanner's buffer

### DIFF
--- a/message/preview.go
+++ b/message/preview.go
@@ -93,6 +93,7 @@ func previewText(r io.Reader) (string, error) {
 	// We look quite a bit of lines ahead for trailing signatures with trailing empty lines.
 	var lines []string
 	scanner := bufio.NewScanner(r)
+	scanner.Split(scanPreviewLines)
 	ensureLines := func() {
 		for len(lines) < 10 && scanner.Scan() {
 			lines = append(lines, strings.TrimSpace(scanner.Text()))
@@ -185,6 +186,33 @@ func previewText(r io.Reader) (string, error) {
 	}
 
 	return result, scanner.Err()
+}
+
+// scanPreviewLines is bufio.ScanLines, except that a line filling the scanner's
+// buffer is returned as a token instead of failing the scan.
+//
+// A text/plain part can be a single very long logical line: quoted-printable
+// soft line breaks mean a body wrapped at 78 columns on the wire can decode
+// into one line of any length, and format=flowed produces the same. Plain
+// bufio.ScanLines answers that with ErrTooLong, which previewText returned and
+// Part.Preview turned into an error, causing the message to be rejected on
+// delivery and on IMAP APPEND. Refusing a message over a preview is severe: a
+// preview is advisory, and RFC 8970 makes no demand that one exists.
+//
+// Truncating loses nothing. Only the first few lines are examined and at most
+// 256 characters are returned, so the remainder of an over-long line could
+// never have reached the result.
+func scanPreviewLines(data []byte, atEOF bool) (int, []byte, error) {
+	advance, token, err := bufio.ScanLines(data, atEOF)
+	if err != nil || token != nil || atEOF {
+		return advance, token, err
+	}
+	// No newline in a full buffer: the scanner is about to give up, so hand back
+	// what there is and carry on with the rest of the line as the next token.
+	if len(data) >= bufio.MaxScanTokenSize {
+		return len(data), data, nil
+	}
+	return advance, token, err
 }
 
 // Any text inside these html elements (recursively) is ignored.

--- a/message/preview_test.go
+++ b/message/preview_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -38,6 +39,35 @@ func TestPreviewText(t *testing.T) {
 	check("On <longdate>\n<user> wrote:\n> hi\nresponse", "[...]\nresponse\n")
 	check("> quote\nresponse\n--\nsignature\n", "[...]\nresponse\n")
 	check("> quote\nline1\nline2\nline3\n", "[...]\nline1\nline2\nline3\n")
+}
+
+// TestPreviewLongLine ensures a single line longer than the scanner's buffer
+// does not fail the preview.
+//
+// Quoted-printable soft line breaks, and format=flowed, both turn a body that
+// is wrapped at 78 columns on the wire into one very long logical line on
+// decode. bufio.ScanLines answers that with ErrTooLong, which previewText
+// returned and Part.Preview turned into an error, so the message was rejected
+// on delivery and on IMAP APPEND. A preview is advisory — RFC 8970 does not
+// require one exists — so refusing the message over it is out of proportion.
+func TestPreviewLongLine(t *testing.T) {
+	long := strings.Repeat("a", bufio.MaxScanTokenSize+100)
+
+	// The result is capped at 256 characters as it is for any other body, so the
+	// bytes past the scanner's buffer could never have been used anyway.
+	s, err := previewText(strings.NewReader(long))
+	tcompare(t, err, nil)
+	tcompare(t, s, strings.Repeat("a", 256))
+
+	// An over-long line must not swallow the lines around it.
+	s, err = previewText(strings.NewReader("first\n" + long + "\nlast\n"))
+	tcompare(t, err, nil)
+	tcompare(t, strings.HasPrefix(s, "first\n"), true)
+
+	// And it must not break a message whose preview is entirely in front of it.
+	s, err = previewText(strings.NewReader("the useful bit\n\n" + long + "\n"))
+	tcompare(t, err, nil)
+	tcompare(t, strings.HasPrefix(s, "the useful bit\n"), true)
 }
 
 func tcompose(t *testing.T, typeContents ...string) *bytes.Reader {


### PR DESCRIPTION
For issue #426 - I ran into the same issue syncing my mails into mox.

previewText scans with a default bufio.Scanner, so a logical line over 64kb makes Scan stop and Err return ErrTooLong. previewText returned that, and Part.Preview turns any error other than moxio.ErrLimit into an error for the TEXT/PLAIN case, so the message was rejected: delivery failed, and IMAP APPEND answered "NO ... generating preview: making preview from text part: bufio.Scanner: token too long".

Such messages are not malformed. Quoted-printable soft line breaks mean a body wrapped at 78 columns on the wire decodes into a single logical line of any length, and format=flowed does the same. One example that triggers this is wrapped correctly at 78 columns and decodes to a single line of 65572 bytes, 36 over the limit. It also carries a text/html alternative of under 6kb, which would have been forgiven, since the TEXT/HTML case logs and continues where TEXT/PLAIN aborts.

Refusing a message over this seems out of proportion: a preview is advisory, and RFC 8970 does not require that one exists.

So scan with a split function that hands back a full buffer as a line instead of giving up. Nothing is lost by truncating: only the first lines are examined and at most 256 characters are returned, so the bytes past the buffer could never have reached the result. Messages that fit today are unaffected, since the split only differs from bufio.ScanLines once the buffer is full.

