### PR TITLE
message: keep the header of a message that failed to parse

### DIFF
--- a/message/part.go
+++ b/message/part.go
@@ -149,9 +149,20 @@ func EnsurePart(elog *slog.Logger, strict bool, r io.ReaderAt, size int64) (Part
 }
 
 func fallbackPart(p Part, r io.ReaderAt, size int64) (Part, error) {
+	headerOffset, bodyOffset := p.HeaderOffset, p.BodyOffset
+	if bodyOffset <= headerOffset {
+		// Parsing stopped before the end of the header was found, e.g. due to a header
+		// line that is too long. Both offsets are still at the start of the header, which
+		// makes the whole message its body: FETCH BODY[HEADER] then returns nothing while
+		// BODY[TEXT] returns the header too. The header is there, so look for its end
+		// again, now without a limit on the length of a line.
+		if o, err := headerEnd(r, headerOffset); err == nil {
+			bodyOffset = o
+		}
+	}
 	np := Part{
-		HeaderOffset:            p.HeaderOffset,
-		BodyOffset:              p.BodyOffset,
+		HeaderOffset:            headerOffset,
+		BodyOffset:              bodyOffset,
 		EndOffset:               size,
 		MediaType:               "APPLICATION",
 		MediaSubType:            "OCTET-STREAM",
@@ -173,6 +184,32 @@ func fallbackPart(p Part, r io.ReaderAt, size int64) (Part, error) {
 	// By reading body, the number of lines and decoded size will be set.
 	_, err := io.Copy(io.Discard, np.Reader())
 	return np, err
+}
+
+// headerEnd returns the offset just after the empty line that ends the header
+// starting at offset, without a limit on the length of the lines in between. Used
+// to recover the split between header and body of a message we could not parse.
+func headerEnd(r io.ReaderAt, offset int64) (int64, error) {
+	sep := []byte("\r\n\r\n")
+	buf := make([]byte, 8*1024)
+	base := offset // Offset in r of buf[0].
+	have := 0
+	for {
+		n, err := r.ReadAt(buf[have:], base+int64(have))
+		have += n
+		if i := bytes.Index(buf[:have], sep); i >= 0 {
+			return base + int64(i+len(sep)), nil
+		}
+		if err != nil {
+			return 0, err
+		}
+		// Buffer full without a match. Keep the trailing bytes that may hold the start of
+		// the separator and continue after them.
+		keep := len(sep) - 1
+		copy(buf, buf[have-keep:have])
+		base += int64(have - keep)
+		have = keep
+	}
 }
 
 // SetReaderAt sets r as reader for this part and all its sub parts, recursively.

--- a/message/part_test.go
+++ b/message/part_test.go
@@ -610,3 +610,39 @@ func TestParseQuotedCharset(t *testing.T) {
 	tcheck(t, err, "parse")
 	tcompare(t, p.Envelope.From, []Address{{"Kristýna", "k", "example.com"}})
 }
+
+func TestFallbackHeaderOffsets(t *testing.T) {
+	// A header line that is too long stops the parse before the end of the header is
+	// found. The fallback part must still split header and body, or FETCH BODY[HEADER]
+	// comes up empty while BODY[TEXT] returns the header too.
+	header := "Subject: test\r\nReferences: " + strings.Repeat("r", 1100) + "\r\n"
+	body := "the body\r\n"
+	s := header + "\r\n" + body
+	p, err := EnsurePart(pkglog.Logger, true, strings.NewReader(s), int64(len(s)))
+	tfail(t, err, errLineTooLong)
+	tcompare(t, p.HeaderOffset, int64(0))
+	tcompare(t, p.BodyOffset, int64(len(header)+2))
+
+	buf, err := io.ReadAll(p.HeaderReader())
+	tcheck(t, err, "read header")
+	tcompare(t, string(buf), header+"\r\n")
+
+	buf, err = io.ReadAll(p.Reader())
+	tcheck(t, err, "read body")
+	tcompare(t, string(buf), body)
+
+	// The scan for the empty line reads in chunks, and the empty line can straddle two
+	// of them.
+	for _, o := range []int{8189, 8190, 8191, 8192, 8193} {
+		header := "References: " + strings.Repeat("r", o-len("References: ")) + "\r\n"
+		s := header + "\r\n" + body
+		p, err := EnsurePart(pkglog.Logger, true, strings.NewReader(s), int64(len(s)))
+		tfail(t, err, errLineTooLong)
+		if p.BodyOffset != int64(o+4) {
+			t.Fatalf("empty line at offset %d: got body offset %d, expected %d", o, p.BodyOffset, o+4)
+		}
+		buf, err := io.ReadAll(p.Reader())
+		tcheck(t, err, "read body")
+		tcompare(t, string(buf), body)
+	}
+}


### PR DESCRIPTION
A message whose parse fails before the end of the header is found is stored with
`HeaderOffset == BodyOffset`, so the whole message becomes its body. Over IMAP,
`FETCH BODY[HEADER]` and `BODY[HEADER.FIELDS (...)]` return a zero-length
literal, while `BODY[TEXT]` returns the header as well.

`newPart` sets both offsets to the start of the header and only moves
`BodyOffset` after reading the empty line that ends it:

```go
p.HeaderOffset = b.offset
p.BodyOffset = b.offset
for {
	line, _, err := b.ReadLine(true)
	...
	if err != nil {
		return p, fmt.Errorf("reading header line: %w", err)  // both offsets still at the start
	}
}
p.BodyOffset = b.offset  // only on success
```

`fallbackPart` copies those offsets verbatim.

### Reproducing

Append a message with one header line longer than `maxLineLength` and fetch it
back. Against `mox localserve`, which sets `Pedantic: true` and so uses the 1000
byte limit:

```
  line   990 bytes -> HEADER  1037  TEXT     7   ok
  line  1000 bytes -> HEADER  1048  TEXT     7   ok
  line  1001 bytes -> HEADER     0  TEXT  1056   <- header empty, body is everything
  line  9000 bytes -> HEADER     0  TEXT  9055   <-
```

With `Pedantic: false` the threshold moves to 8192, as `maxLineLength()` says,
and the behaviour above 8192 is the same. Same results on a clean checkout of
main and on a branch of my own, so it is not something local to me.

The APPEND is accepted, so the message is stored this way permanently.

### Why such a message shows up

SMTP submission rejects it: `550 5.6.0 cannot parse header or From address:
parsing message: reading header line: line too long`. Inbound delivery logs the
parse error and continues (`smtpserver/server.go`, in `deliver`), and IMAP
APPEND has no such gate at all.

I ran into it migrating a mailbox into mox with an IMAP client: 19 messages out
of 11770 in a Sent mailbox, all filed there by Apple Mail, which appends its own
copy of a sent message and writes `References` unfolded. A long enough thread
gives a header line over 998 bytes. The messages are malformed, but mox has
decided to keep them rather than reject them, and `MessageAdd` notes "p is still
valid" where it stores the part.

### The change

Look for the end of the header again in the fallback, without a limit on line
length. Only when parsing stopped before the split was established, so a part
whose header parsed and that failed later keeps the offsets it has; if there is
no empty line at all, nothing changes. Messages that parse today are unaffected,
since `fallbackPart` is only reached after an error.

Existing messages can be repaired with `mox reparse`.

The test covers the basic case and the empty line straddling two chunks of the
scan. `go test ./message/ ./imapserver/ ./store/ ./smtpserver/ ./webmail/` passes.

### Not addressed

The fallback still reports `application/octet-stream` with an empty envelope, so
`ENVELOPE` and `BODYSTRUCTURE` stay uninformative for these messages even though
the header is now readable. Parsing the recovered header to fill those in, or
skipping just the over-long field so the message parses normally, both seemed
like bigger decisions than this fix, and I would rather leave them to you.
