### PR TITLE
dnsbl monitor: don't set mox_dnsbl_ips_success to 0 on temporary DNS errors

### DIFF
--- a/dnsbl_monitor_test.go
+++ b/dnsbl_monitor_test.go
@@ -1,0 +1,73 @@
+//go:build !windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/mjl-/mox/dns"
+	"github.com/mjl-/mox/dnsbl"
+)
+
+// dnsblMetricValue returns the value of the mox_dnsbl_ips_success gauge for the
+// given zone and ip.
+func dnsblMetricValue(t *testing.T, zoneName, ip string) float64 {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(metricDNSBL)
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "mox_dnsbl_ips_success" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["zone"] == zoneName && labels["ip"] == ip {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	t.Fatalf("mox_dnsbl_ips_success{zone=%q,ip=%q} not found", zoneName, ip)
+	return 0
+}
+
+func TestMonitorDNSBLTemperror(t *testing.T) {
+	zone := dns.Domain{ASCII: "sbl.spamhaus.org."}
+	ip := "1.2.3.4"
+	zoneName := zone.Name()
+
+	// Set a previous value, as a previous successful check would have.
+	metricDNSBL.WithLabelValues(zoneName, ip).Set(1)
+
+	if got := dnsblMetricValue(t, zoneName, ip); got != 1 {
+		t.Fatalf("initial gauge value is %v, expected 1", got)
+	}
+
+	// A temporary DNS error, e.g. "server misbehaving", is not an indication that
+	// our IP is in the block list, it should not update the gauge.
+	updateDNSBLMetric(zone, ip, dnsbl.StatusTemperr)
+
+	if got := dnsblMetricValue(t, zoneName, ip); got != 1 {
+		t.Fatalf("gauge is %v after temperror, expected it to keep the previous value 1", got)
+	}
+
+	// A successful lookup resets the gauge to 1.
+	updateDNSBLMetric(zone, ip, dnsbl.StatusPass)
+	if got := dnsblMetricValue(t, zoneName, ip); got != 1 {
+		t.Fatalf("gauge is %v after pass, expected 1", got)
+	}
+
+	// Being in the block list sets the gauge to 0.
+	updateDNSBLMetric(zone, ip, dnsbl.StatusFail)
+	if got := dnsblMetricValue(t, zoneName, ip); got != 0 {
+		t.Fatalf("gauge is %v after fail, expected 0", got)
+	}
+}

--- a/serve_unix.go
+++ b/serve_unix.go
@@ -131,11 +131,7 @@ func monitorDNSBL(log mlog.Log) {
 						slog.String("expl", expl),
 						slog.Any("status", status))
 				}
-				var v float64
-				if status == dnsbl.StatusPass {
-					v = 1
-				}
-				metricDNSBL.WithLabelValues(zone.Name(), ip.String()).Set(v)
+				updateDNSBLMetric(zone, ip.String(), status)
 				k := key{zone, ip.String()}
 				prevResults[k] = struct{}{}
 
@@ -143,6 +139,19 @@ func monitorDNSBL(log mlog.Log) {
 			}
 		}
 	}
+}
+
+func updateDNSBLMetric(zone dns.Domain, ip string, status dnsbl.Status) {
+	// A temporary DNS error is not an indication of whether our IP is in the block
+	// list, don't update the metric for it, keep the previous known value.
+	if status == dnsbl.StatusTemperr {
+		return
+	}
+	var v float64
+	if status == dnsbl.StatusPass {
+		v = 1
+	}
+	metricDNSBL.WithLabelValues(zone.Name(), ip).Set(v)
 }
 
 // also see localserve.go, code is similar or even shared.


### PR DESCRIPTION
# Don't set `mox_dnsbl_ips_success` to 0 on temporary DNS errors

## What this fixes

The `mox_dnsbl_ips_success` gauge drops to `0` when a DNSBL lookup hits a
temporary DNS error — e.g. a resolver answering "server misbehaving":

```
l=error m="dnsbl monitor lookup" err="dnsbl: dns error: lookup 47.223.230.185.sbl.spamhaus.org. ... server misbehaving" ... status=temperror
```

resulting in:

```
mox_dnsbl_ips_success{ip="185.230.223.47",zone="sbl.spamhaus.org"} 0
```

A temperror says nothing about whether the IP is in the block list, so this
is a false alarm: the issue reporter got a surprise Sunday-morning alert
from it (#445).

## Why it happens

The DNSBL monitor only ever sets the gauge to `1` on `dnsbl.StatusPass`;
every other status — including `dnsbl.StatusTemperr` — falls through to
`Set(0)`. `StatusTemperr` is its own outcome: any A-lookup error other than
NXDOMAIN (timeout, SERVFAIL, "server misbehaving") maps to it, distinct
from `StatusFail`.

## The fix

Skip the gauge update on `StatusTemperr`, so the metric keeps the last
known value until a conclusive result arrives. `pass` → `1` and `fail` →
`0` semantics are unchanged, and the separate `-1` "broken" value (set
when listing our own IPs fails) is untouched.

One side effect worth noting: a zone/ip combination that has only ever
seen temperrors has no gauge series at all, instead of one showing `0`.
For alerting on this metric that is the safer default — a missing series
is not mistaken for "listed".

## Tests

New `TestMonitorDNSBLTemperror` (root package, same `!windows` build tag
as `serve_unix.go` where the gauge lives): seeds the gauge to `1`, asserts
a temperror leaves it at `1`, then asserts `pass` → `1` and `fail` → `0`
still work. Red without the fix ("gauge is 0 after temperror"), green with
it. `go test ./dnsbl/... ./dns/... .` all pass, `go build ./...`, `go vet`
and `gofmt` clean.

Fixes #445
